### PR TITLE
include deployments-enterprise in watch repos

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,7 +67,9 @@ func getConfig() (*config, error) {
 			"mender-conductor-enterprise",
 			"meta-mender",
 			"mender-api-gateway-docker",
-			"tenantadm"}
+			"tenantadm",
+			"deployments-enterprise",
+		}
 
 	watchRepositories := os.Getenv("WATCH_REPOS")
 


### PR DESCRIPTION
https://tracker.mender.io/browse/MEN-2652

supports https://github.com/mendersoftware/deployments-enterprise/pull/1

@kacf is this the correct way to automatically start integration for a repo?