### PR TITLE
QA-107: Keep OS and Enterprise repos in sync

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,20 +3,21 @@ package main
 import (
 	"context"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
+	"reflect"
+	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
-	"io/ioutil"
-	"sort"
-	"reflect"
 
 	"github.com/davecgh/go-spew/spew"
+	"github.com/gin-gonic/gin"
 	"github.com/google/go-github/github"
 	"github.com/xanzy/go-gitlab"
 	"golang.org/x/oauth2"
-	"github.com/gin-gonic/gin"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -34,11 +35,11 @@ type config struct {
 }
 
 type buildOptions struct {
-	pr               string
-	repo             string
-	baseBranch       string
-	commitSHA        string
-	makeQEMU         bool
+	pr         string
+	repo       string
+	baseBranch string
+	commitSHA  string
+	makeQEMU   bool
 }
 
 const (
@@ -96,12 +97,12 @@ func getConfig() (*config, error) {
 	}
 
 	return &config{
-		githubSecret:          []byte(githubSecret),
-		githubToken:           githubToken,
-		gitlabToken:           gitlabToken,
-		gitlabBaseURL:         gitlabBaseURL,
-		watchRepositories:     repositoryWatchList,
-		integrationDirectory:  integrationDirectory,
+		githubSecret:         []byte(githubSecret),
+		githubToken:          githubToken,
+		gitlabToken:          gitlabToken,
+		gitlabBaseURL:        gitlabBaseURL,
+		watchRepositories:    repositoryWatchList,
+		integrationDirectory: integrationDirectory,
 	}, nil
 }
 
@@ -157,6 +158,11 @@ func main() {
 			mutex.Lock()
 			builds := parsePullRequest(conf, action, pr)
 			log.Infof("%s:%d triggered %d builds: \n", *pr.Repo.Name, pr.GetNumber(), len(builds))
+
+			// Keep the OS and Enterprise repos in sync
+			if err = syncIfOSHasEnterpriseRepo(conf, pr); err != nil {
+				log.Errorf("Failed to sync the OS and Enterprise repos: %s", err.Error())
+			}
 			mutex.Unlock()
 
 			for idx, build := range builds {
@@ -208,11 +214,11 @@ func parsePullRequest(conf *config, action string, pr *github.PullRequestEvent) 
 				switch repo {
 				case "meta-mender", "integration":
 					build := buildOptions{
-						pr:               strconv.Itoa(pr.GetNumber()),
-						repo:             repo,
-						baseBranch:       baseBranch,
-						commitSHA:        commitSHA,
-						makeQEMU:         makeQEMU,
+						pr:         strconv.Itoa(pr.GetNumber()),
+						repo:       repo,
+						baseBranch: baseBranch,
+						commitSHA:  commitSHA,
+						makeQEMU:   makeQEMU,
 					}
 					builds = append(builds, build)
 
@@ -228,11 +234,11 @@ func parsePullRequest(conf *config, action string, pr *github.PullRequestEvent) 
 					// one pull request can trigger multiple builds
 					for _, integrationBranch := range integrationsToTest {
 						buildOpts := buildOptions{
-							pr:               strconv.Itoa(pr.GetNumber()),
-							repo:             repo,
-							baseBranch:       integrationBranch,
-							commitSHA:        commitSHA,
-							makeQEMU:         makeQEMU,
+							pr:         strconv.Itoa(pr.GetNumber()),
+							repo:       repo,
+							baseBranch: integrationBranch,
+							commitSHA:  commitSHA,
+							makeQEMU:   makeQEMU,
 						}
 						builds = append(builds, buildOpts)
 					}
@@ -328,14 +334,14 @@ func triggerBuild(conf *config, build *buildOptions) error {
 
 	buildParameters = append(buildParameters, &gitlab.PipelineVariable{"BUILD_BEAGLEBONEBLACK", qemuParam})
 
-	// first stop old pipelines with ame buildParameters
+	// first stop old pipelines with the same buildParameters
 	stopStalePipelines(gitlabClient, buildParameters)
 
 	// trigger the new pipeline
 	integrationPipelinePath := "Northern.tech/Mender/mender-qa"
 	ref := "master"
 	opt := &gitlab.CreatePipelineOptions{
-		Ref: &ref,
+		Ref:       &ref,
 		Variables: buildParameters,
 	}
 
@@ -374,14 +380,14 @@ func createPullRequestBranch(repo, pr, action string) error {
 		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
-	gitcmd = exec.Command("git", "remote", "add", "github", "git@github.com:mendersoftware/" + repo)
+	gitcmd = exec.Command("git", "remote", "add", "github", "git@github.com:mendersoftware/"+repo)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
-	gitcmd = exec.Command("git", "remote", "add", "gitlab", "git@gitlab.com:Northern.tech/Mender/" + repo)
+	gitcmd = exec.Command("git", "remote", "add", "gitlab", "git@gitlab.com:Northern.tech/Mender/"+repo)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {
@@ -389,14 +395,14 @@ func createPullRequestBranch(repo, pr, action string) error {
 	}
 
 	prBranchName := "pr_" + pr
-	gitcmd = exec.Command("git", "fetch", "github", "pull/" + pr + "/head:" + prBranchName )
+	gitcmd = exec.Command("git", "fetch", "github", "pull/"+pr+"/head:"+prBranchName)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
-	gitcmd = exec.Command("git", "push", "-f", "--set-upstream", "gitlab", prBranchName )
+	gitcmd = exec.Command("git", "push", "-f", "--set-upstream", "gitlab", prBranchName)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {
@@ -408,7 +414,7 @@ func createPullRequestBranch(repo, pr, action string) error {
 	return nil
 }
 
-func stopStalePipelines (client *gitlab.Client, vars []*gitlab.PipelineVariable) {
+func stopStalePipelines(client *gitlab.Client, vars []*gitlab.PipelineVariable) {
 	integrationPipelinePath := "Northern.tech/Mender/mender-qa"
 
 	sort.SliceStable(vars, func(i, j int) bool {
@@ -419,7 +425,7 @@ func stopStalePipelines (client *gitlab.Client, vars []*gitlab.PipelineVariable)
 	status := gitlab.Pending
 	opt := &gitlab.ListProjectPipelinesOptions{
 		Username: &username,
-		Status: &status,
+		Status:   &status,
 	}
 
 	pipelinesPending, _, err := client.Pipelines.ListProjectPipelines(integrationPipelinePath, opt, nil)
@@ -430,7 +436,7 @@ func stopStalePipelines (client *gitlab.Client, vars []*gitlab.PipelineVariable)
 	status = gitlab.Running
 	opt = &gitlab.ListProjectPipelinesOptions{
 		Username: &username,
-		Status: &status,
+		Status:   &status,
 	}
 
 	pipelinesRunning, _, err := client.Pipelines.ListProjectPipelines(integrationPipelinePath, opt, nil)
@@ -461,4 +467,294 @@ func stopStalePipelines (client *gitlab.Client, vars []*gitlab.PipelineVariable)
 		}
 
 	}
+}
+
+// syncIfOSHasEnterpriseRepo detects whether a commit has been merged to
+// the Open Source edition of a repo, and then creates a PR-branch
+// in the Enterprise edition, which is then used in order to open
+// a PR to the Enterprise repo with the OS changes.
+func syncIfOSHasEnterpriseRepo(conf *config, gpr *github.PullRequestEvent) error {
+
+	repo := gpr.GetRepo()
+	if repo == nil {
+		return fmt.Errorf("syncIfOSHasEnterpriseRepo: Failed to get the repository information")
+	}
+
+	// Enterprise repo sentinel
+	switch repo.GetName() {
+	case "deployments":
+	case "useradm":
+	default:
+		log.Debugf("syncIfOSHasEnterpriseRepo: Repository without Enterprise fork detected: (%s). Not syncing", repo.GetName())
+		return nil
+	}
+
+	pr := gpr.GetPullRequest()
+	if pr == nil {
+		return fmt.Errorf("syncIfOSHasEnterpriseRepo: Failed to get the pull request")
+	}
+
+	// If the action is "closed" and the "merged" key is "true", the pull request was merged.
+	// While webhooks are also triggered when a pull request is synchronized, Events API timelines
+	// don't include pull request events with the "synchronize" action.
+	if gpr.GetAction() == "closed" && pr.GetMerged() {
+
+		// Only sync on Merges to master or release branches and
+		// verify release branches.
+		branch := pr.GetBase()
+		if branch == nil {
+			return fmt.Errorf("syncIfOSHasEnterpriseRepo: Failed to get the base-branch of the PR: %v", branch)
+		}
+
+		syncBranches := regexp.MustCompile(`(master|[0-9]+\.[0-9]+\.x)`)
+		branchRef := branch.GetRef()
+		if branchRef == "" {
+			return fmt.Errorf("Failed to get the branch-ref from the PR: %v", pr)
+		}
+		if !syncBranches.MatchString(branchRef) {
+
+			log.Debugf("syncIfOSHasEnterpriseRepo: Detected a merge into another branch than master or a release branch: (%s), no syncing done", branchRef)
+
+		} else {
+
+			log.Infof("syncIfOSHasEnterpriseRepo: Merge to (%s) in an OS repository detected. Syncing the repositories...", branchRef)
+
+			PRNumber := strconv.Itoa(pr.GetNumber())
+			PRBranchName := "mergeostoent_" + PRNumber
+
+			merged, err := createPRBranchOnEnterprise(repo.GetName(), branchRef, PRNumber, PRBranchName)
+			if err != nil {
+				return fmt.Errorf("syncIfOSHasEnterpriseRepo: Failed to create the PR branch on the Enterprise repo due to error: %v", err)
+			}
+
+			// Get the link to the original PR, so that it can be linked to
+			// in the commit body
+			PRURL := pr.GetHTMLURL()
+
+			enterprisePR, err := createPullRequestFromTestBotFork(createPRArgs{
+				conf:        conf,
+				repo:        repo.GetName() + "-enterprise",
+				prBranch:    "mender-test-bot:" + PRBranchName,
+				baseBranch:  branchRef,
+				message:     fmt.Sprintf("[Bot] %s", pr.GetTitle()),
+				messageBody: fmt.Sprintf("Original PR: %s\n\n%s", PRURL, pr.GetBody()),
+			})
+			if err != nil {
+				return fmt.Errorf("syncIfOSHasEnterpriseRepo: Failed to create a PR with error: %v", err)
+			}
+
+			log.Infof("syncIfOSHasEnterpriseRepo: Created PR: %s on Enterprise/%s/%s",
+				enterprisePR.GetNumber(), repo.GetName(), branchRef)
+			log.Debugf("syncIfOSHasEnterpriseRepo: Created PR: %v", pr)
+			log.Debug("Trying to @mention the user in the newly created PR")
+			userName := pr.GetMergedBy().GetLogin()
+			log.Debugf("userName: %s", userName)
+
+			if userName != "" {
+				err = commentToNotifyUser(commentArgs{
+					pr:             enterprisePR,
+					conf:           conf,
+					mergeConflicts: !merged,
+					repo:           repo.GetName() + "-enterprise",
+					userName:       userName,
+				})
+				if err != nil {
+					log.Errorf("syncIfOSHasEnterpriseRepo: %s", err.Error())
+				}
+			}
+
+		}
+
+	}
+
+	return nil
+}
+
+// createPRBranchOnEnterprise creates a new branch in the Enterprise repository
+// starting at the branch in which to sync, with the name 'PRBranchName'
+// and merges this with the OS equivalent of 'branchName'.
+func createPRBranchOnEnterprise(repo, branchName, PRNumber, PRBranchName string) (merged bool, err error) {
+
+	tmpdir, err := ioutil.TempDir("", repo)
+	if err != nil {
+		return false, err
+	}
+	defer os.RemoveAll(tmpdir)
+
+	gitcmd := exec.Command("git", "init", ".")
+	gitcmd.Dir = tmpdir
+	out, err := gitcmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	gitcmd = exec.Command("git", "remote", "add", "opensource", "git@github.com:mendersoftware/"+repo+".git")
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	gitcmd = exec.Command("git", "remote", "add", "enterprise", "git@github.com:mendersoftware/"+repo+"-enterprise"+".git")
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	gitcmd = exec.Command("git", "remote", "add", "mender-test-bot", "git@github.com:mender-test-bot/"+repo+"-enterprise"+".git")
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	// Set the local name to 'mender-test-bot', and the local
+	// email to 'mender@northern.tech'
+	gitcmd = exec.Command("git", "config", "--add", "user.name", "mender-test-bot")
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+	gitcmd = exec.Command("git", "config", "--add", "user.email", "mender@northern.tech")
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	// Fetch the branch which we are going to sync
+	gitcmd = exec.Command("git", "fetch", "opensource", branchName)
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	// Fetch the Enterprise branch in which to merge into, and create the PR branch
+	gitcmd = exec.Command("git", "fetch", "enterprise", branchName+":"+PRBranchName)
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	// Checkout the enterprise PR branch
+	gitcmd = exec.Command("git", "checkout", PRBranchName)
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return false, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	// Merge the OS branch into the PR branch
+	mergeMsg := fmt.Sprintf("Merge OS base branch: (%s) including PR: (%s) into Enterprise: (%[1]s)",
+		branchName, PRNumber)
+	log.Debug("Trying to " + mergeMsg)
+	gitcmd = exec.Command("git", "merge", "-m", mergeMsg, "opensource/"+branchName)
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	merged = true
+	if err != nil {
+		merged = false
+		if strings.Contains(string(out), "Automatic merge failed") {
+			msg := "Merge conflict detected. Still pushing the Enterprise PR branch, " +
+				"and creating the PR, so that the user can manually resolve, " +
+				"and re-push to the PR once these are fixed"
+			log.Warn(msg)
+		} else {
+			return false, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+		}
+	}
+
+	if !merged {
+		// In case of a failed merge, reset PRBranchName to opensource/branchName
+		// and push this branch to enterprise
+		gitcmd = exec.Command("git", "reset", "--hard", "opensource/"+branchName)
+		gitcmd.Dir = tmpdir
+		out, err = gitcmd.CombinedOutput()
+		if err != nil {
+			return merged, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+		}
+	}
+
+	// Push the branch to the mender-test-bot's own fork
+	gitcmd = exec.Command("git", "push", "--set-upstream", "mender-test-bot", PRBranchName)
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return merged, fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	if merged {
+		log.Infof("Merged branch: opensource/%s/%s into enterprise/%[1]s/%s in the Enterprise repo",
+			repo, branchName, PRBranchName)
+	} else {
+		msg := "Failed to merge opensource/%s/%s into enterprise/%[1]s/%s in the Enterprise repo. " +
+			"Therefore pushed opensource/%[1]s/%[2]s to %s so that " +
+			"merging can be done by a human locally"
+		log.Infof(msg, repo, branchName, PRBranchName, PRBranchName)
+	}
+
+	return merged, nil
+}
+
+type createPRArgs struct {
+	conf        *config
+	repo        string
+	prBranch    string
+	baseBranch  string
+	message     string
+	messageBody string
+}
+
+func createPullRequestFromTestBotFork(args createPRArgs) (*github.PullRequest, error) {
+
+	client := createGitHubClient(args.conf)
+
+	newPR := &github.NewPullRequest{
+		Title:               github.String(args.message),
+		Head:                github.String(args.prBranch),
+		Base:                github.String(args.baseBranch),
+		Body:                github.String(args.messageBody),
+		MaintainerCanModify: github.Bool(true),
+	}
+
+	pr, _, err := client.PullRequests.Create(context.Background(), "mendersoftware", args.repo, newPR)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to create the PR for: (%s) %v", args.repo, err)
+	}
+
+	return pr, nil
+}
+
+type commentArgs struct {
+	pr             *github.PullRequest
+	conf           *config
+	mergeConflicts bool
+	repo           string
+	userName       string
+}
+
+func commentToNotifyUser(args commentArgs) error {
+
+	// Post a comment, and @mention the user
+	var commentBody string
+	if !args.mergeConflicts {
+		commentBody = fmt.Sprintf("@%s I have created a PR for you, ready to merge as soon as tests are passed", args.userName)
+	} else {
+		msg := "@%s I have created a PR for you. Unfortunately there were some merge conflicts " +
+			"which I failed to resolve automatically. Therefore the branch of this PR " +
+			"is ready to be merged locally, and then pushed here :)"
+		commentBody = fmt.Sprintf(msg, args.userName)
+	}
+	comment := github.IssueComment{
+		Body: &commentBody,
+	}
+	client := createGitHubClient(args.conf)
+
+	_, _, err := client.Issues.CreateComment(context.Background(), "mendersoftware", args.repo, args.pr.GetNumber(), &comment)
+
+	return err
 }

--- a/main.go
+++ b/main.go
@@ -53,6 +53,19 @@ func getConfig() (*config, error) {
 	gitlabToken := os.Getenv("GITLAB_TOKEN")
 	gitlabBaseURL := os.Getenv("GITLAB_BASE_URL")
 	integrationDirectory := os.Getenv("INTEGRATION_DIRECTORY")
+	logLevel, found := os.LookupEnv("INTEGRATION_TEST_RUNNER_LOG_LEVEL")
+
+	log.SetLevel(log.InfoLevel)
+
+	if found {
+		lvl, err := log.ParseLevel(logLevel)
+		if err != nil {
+			log.Infof("Failed to parse the 'INTEGRATION_TEST_RUNNER_LOG_LEVEL' variable, defaulting to 'InfoLevel'")
+		} else {
+			log.Infof("Set 'LogLevel' to %s", lvl)
+			log.SetLevel(lvl)
+		}
+	}
 
 	// if no env. variable is set, this is the default repo watch list
 	defaultWatchRepositories :=


### PR DESCRIPTION
Note: This functionality relies on an external tool:
https://github.com/containous/gallienii to keep the repos in sync. When the
integration-test-runner detects a merge into one of the OS repositories with an
Enterprise fork, then an HTTP GET request is sent to the gallienii server, which
is running as a seperate service on the server. Then gallienii will run its sync
functionality which syncs all Enterprise repos with its OS counterpart. Note
that this is not specific to the merged PR, and hence all unsynchronized code
across all Enterprise repos will get a PR with the missing code. The gallienii
server will be listening to a configureable port, given by the GALLIENI_PORT
environment variable.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>