### PR TITLE
Fix: Build PR's moved out of the 'Draft' status

### DIFF
--- a/main.go
+++ b/main.go
@@ -205,7 +205,8 @@ func parsePullRequest(conf *config, action string, pr *github.PullRequestEvent) 
 	commitSHA := pr.PullRequest.Head.GetSHA()
 
 	// github pull request events to trigger a jenkins job for
-	if action == "opened" || action == "edited" || action == "reopened" || action == "synchronize" {
+	if action == "opened" || action == "edited" || action == "reopened" ||
+		action == "synchronize" || action == "ready_for_review" {
 
 		//GetLabel returns "mendersoftware:master", we just want the branch
 		baseBranch := strings.Split(pr.PullRequest.Base.GetLabel(), ":")[1]
@@ -377,7 +378,8 @@ func triggerBuild(conf *config, build *buildOptions) error {
 
 func createPullRequestBranch(repo, pr, action string) error {
 
-	if action != "opened" && action != "edited" && action != "reopened" && action != "synchronize" {
+	if action != "opened" && action != "edited" && action != "reopened" &&
+		action != "synchronize" && action != "ready_for_review" {
 		log.Infof("Action %s, ignoring", action)
 		return nil
 	}


### PR DESCRIPTION
The Github PR's will not get the status 'opened', like a regular PR when moved
out of the 'Draft' state. However, it gets the status 'ready_for_review', which
currently is not a recognized action in the integration-test-runner.

This fix adds the 'ready_for_review' status to the accepted status for builds.

Changelog: None

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>