### PR TITLE
QA-122: Stop stale builds when merging a PR

### DIFF
--- a/main.go
+++ b/main.go
@@ -317,8 +317,8 @@ func triggerBuild(conf *config, build *buildOptions, pr *github.PullRequestEvent
 	}
 	log.Infof("Created pipeline: %s", pipeline.WebURL)
 
-	// Comment with a build-tag and pipeline-link on the PR!
-	commentBody := fmt.Sprintf("[![build-status](https://gitlab.com/Northern.tech/Mender/%s/badges/%s/pipeline.svg)](%s)", *pr.Repo.Name, "pr_"+strconv.Itoa(pr.GetNumber()), pipeline.WebURL)
+	// Comment with a pipeline-link on the PR
+	commentBody := fmt.Sprintf("[pipeline](%s)", *pr.Repo.Name, "pr_"+strconv.Itoa(pr.GetNumber()), pipeline.WebURL)
 	comment := github.IssueComment{
 		Body: &commentBody,
 	}

--- a/main.go
+++ b/main.go
@@ -312,7 +312,8 @@ func triggerBuild(conf *config, build *buildOptions, pr *github.PullRequestEvent
 	log.Infof("Created pipeline: %s", pipeline.WebURL)
 
 	// Comment with a build-tag and pipeline-link on the PR!
-	commentBody := fmt.Sprintf("Pipeline: https://gitlab.com/Northern.tech/Mender/%s/badges/%s/pipeline.svg\n%s", *pr.Repo.Name, pr.GetNumber(), pipeline.WebURL)
+	log.Debug("triggerBuild: Commenting on PR in: %s, with number: %d, and URL: %s", pr.Repo.Name, pr.GetNumber(), pipeline.WebURL)
+	commentBody := fmt.Sprintf("Pipeline: https://gitlab.com/Northern.tech/Mender/%s/badges/%s/pipeline.svg\n%s", *pr.Repo.Name, "pr_"+strconv.Itoa(pr.GetNumber()), pipeline.WebURL)
 	comment := github.IssueComment{
 		Body: &commentBody,
 	}

--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func triggerBuild(conf *config, build *buildOptions, pr *github.PullRequestEvent
 	log.Infof("Created pipeline: %s", pipeline.WebURL)
 
 	// Comment with a pipeline-link on the PR
-	commentBody := fmt.Sprintf("I created a pipeline for you here:\n\t[Pipeline-%d](%s)", pipeline.ID, pipeline.WebURL)
+	commentBody := fmt.Sprintf("Hello, I created a pipeline for you here: [Pipeline-%d](%s)", pipeline.ID, pipeline.WebURL)
 	comment := github.IssueComment{
 		Body: &commentBody,
 	}

--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func triggerBuild(conf *config, build *buildOptions, pr *github.PullRequestEvent
 	log.Infof("Created pipeline: %s", pipeline.WebURL)
 
 	// Comment with a pipeline-link on the PR
-	commentBody := fmt.Sprintf("Hello, I created a pipeline for you here: [Pipeline-%d](%s)", pipeline.ID, pipeline.WebURL)
+	commentBody := fmt.Sprintf("Hello :smile_cat: I created a pipeline for you here: [Pipeline-%d](%s)", pipeline.ID, pipeline.WebURL)
 	comment := github.IssueComment{
 		Body: &commentBody,
 	}

--- a/main.go
+++ b/main.go
@@ -167,7 +167,6 @@ func main() {
 
 			// First check if the PR has been merged. If so, stop
 			// the pipeline, and do nothing else.
-			log.Debugf("Parsed the PR and found: %d builds...", len(builds))
 			if err = stopBuildsOfMergedPRs(pr, conf); err != nil {
 				log.Errorf("Failed to stop a stale build after the PR: %v was merged. Error: %v", pr, err)
 			}

--- a/main.go
+++ b/main.go
@@ -181,6 +181,7 @@ func main() {
 			// Then, continue to the integration Pipeline only for mendersoftware members
 			if member, _, _ := githubClient.Organizations.IsMember(context, "mendersoftware", pr.Sender.GetLogin()); !member {
 				log.Warnf("%s is making a pullrequest, but he/she is not a member of mendersoftware, ignoring", pr.Sender.GetLogin())
+				mutex.Unlock()
 				return
 			}
 

--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func triggerBuild(conf *config, build *buildOptions, pr *github.PullRequestEvent
 	log.Infof("Created pipeline: %s", pipeline.WebURL)
 
 	// Comment with a pipeline-link on the PR
-	commentBody := fmt.Sprintf("[pipeline](%s)", *pr.Repo.Name, "pr_"+strconv.Itoa(pr.GetNumber()), pipeline.WebURL)
+	commentBody := fmt.Sprintf("[pipeline](%s)", pipeline.WebURL)
 	comment := github.IssueComment{
 		Body: &commentBody,
 	}

--- a/main.go
+++ b/main.go
@@ -320,7 +320,7 @@ func triggerBuild(conf *config, build *buildOptions, pr *github.PullRequestEvent
 
 	// Comment with a build-tag and pipeline-link on the PR!
 	log.Debug("triggerBuild: Commenting on PR in: %s, with number: %d, and URL: %s", pr.Repo.Name, pr.GetNumber(), pipeline.WebURL)
-	commentBody := fmt.Sprintf("Pipeline: https://gitlab.com/Northern.tech/Mender/%s/badges/%s/pipeline.svg\n%s", *pr.Repo.Name, "pr_"+strconv.Itoa(pr.GetNumber()), pipeline.WebURL)
+	commentBody := fmt.Sprintf("[![build-status](https://gitlab.com/Northern.tech/Mender/%s/badges/%s/pipeline.svg)](%s)", *pr.Repo.Name, "pr_"+strconv.Itoa(pr.GetNumber()), pipeline.WebURL)
 	comment := github.IssueComment{
 		Body: &commentBody,
 	}

--- a/main.go
+++ b/main.go
@@ -318,7 +318,7 @@ func triggerBuild(conf *config, build *buildOptions, pr *github.PullRequestEvent
 	log.Infof("Created pipeline: %s", pipeline.WebURL)
 
 	// Comment with a pipeline-link on the PR
-	commentBody := fmt.Sprintf("[pipeline](%s)", pipeline.WebURL)
+	commentBody := fmt.Sprintf("I created a pipeline for you here:\n\t[Pipeline-%d](%s)", pipeline.ID, pipeline.WebURL)
 	comment := github.IssueComment{
 		Body: &commentBody,
 	}


### PR DESCRIPTION
No need to keep running a PR test-pipeline if the tests have already been
merged. Thus kill the stale-builds, and return.

Changelog: Title

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>