### PR TITLE
QA-171: Redo function to use --in-integration-version

### DIFF
--- a/main.go
+++ b/main.go
@@ -770,7 +770,7 @@ func getBuildParameters(conf *config, build *buildOptions) ([]*gitlab.PipelineVa
 		if versionedRepo != build.repo &&
 			versionedRepo != "integration" &&
 			build.repo != "meta-mender" {
-			if version, err := getServiceRevisionFromIntegration(versionedRepo, build.baseBranch); err != nil {
+			if version, err := getServiceRevisionFromIntegration(versionedRepo, build.baseBranch, conf); err != nil {
 				log.Errorf("failed to determine %s version: %s", versionedRepo, err.Error())
 				return nil, err
 			} else {


### PR DESCRIPTION
The previous approach will not work when adding new repos: these will be
listed in master but not present in integration/2.x.x branches.

The original reason to do this clones is unknown.