### PR TITLE
Only show non-empty values in the build matrix

### DIFF
--- a/main.go
+++ b/main.go
@@ -377,7 +377,7 @@ Hello :smile_cat: I created a pipeline for you here: [Pipeline-{{.Pipeline.ID}}]
 
 | Key   | Value |
 | ----- | ----- |
-{{range $i, $var := .BuildVars}} | {{$var.Key}} | {{$var.Value}} |
+{{range $i, $var := .BuildVars}}{{if $var.Value}}| {{$var.Key}} | {{$var.Value}} |{{end}}
 {{end}}
 
  </p></details>


### PR DESCRIPTION
There is really no need for the empty placeholders I think.

Besides, it's fugly.

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>