### PR TITLE
Fixes for image in kubernetes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ ADD ./ .
 RUN CGO_ENABLED=0 go build
 
 FROM alpine:3.11
-EXPOSE 8083
+EXPOSE 8080
 RUN apk add git openssh python3 py3-pip
 RUN pip3 install --upgrade pyyaml
 RUN mkdir -p /root/.ssh/ && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,10 +6,16 @@ RUN CGO_ENABLED=0 go build
 
 FROM alpine:3.11
 EXPOSE 8083
-RUN apk add git
+RUN apk add git openssh python3 py3-pip
+RUN pip3 install --upgrade pyyaml
+RUN mkdir -p /root/.ssh/ && \
+    git config --global user.name "Mender Root" && \
+    git config --global user.email root@mender-jenkins.mender.io
 RUN git clone https://github.com/mendersoftware/integration.git /integration
 ENV INTEGRATION_DIRECTORY="/integration/"
+ENV PATH="/integration/extra:${PATH}"
 ENV GIN_RELEASE=release
 ENV INTEGRATION_TEST_RUNNER_LOG_LEVEL=debug
 COPY --from=builder /go/src/github.com/mendersoftware/integration-test-runner/integration-test-runner /
-ENTRYPOINT ["/integration-test-runner"]
+ADD ./entrypoint /
+ENTRYPOINT ["/entrypoint"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -3,7 +3,7 @@ services:
   integration-test-runner:
     build: .
     ports:
-      - "8083:8083"
+      - "8080:8080"
     environment:
       - GITLAB_BASE_URL=https://gitlab.com/api/v4
       - GITHUB_TOKEN=$GITHUB_TOKEN

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,3 +9,6 @@ services:
       - GITHUB_TOKEN=$GITHUB_TOKEN
       - GITHUB_SECRET=$GITHUB_SECRET
       - GITLAB_TOKEN=$GITLAB_TOKEN
+    # volumes:
+    #   - <path/to/key>:/root/.ssh/id_rsa
+    #   - <path/to/key.pub>:/root/.ssh/id_rsa.pub

--- a/entrypoint
+++ b/entrypoint
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+ssh-keyscan github.com >> /root/.ssh/known_hosts
+
+/integration-test-runner

--- a/main.go
+++ b/main.go
@@ -175,6 +175,7 @@ func main() {
 	githubClient := createGitHubClient(conf)
 	r := gin.Default()
 
+	// webhook for GitHub
 	r.POST("/", func(context *gin.Context) {
 		payload, err := github.ValidatePayload(context.Request, conf.githubSecret)
 
@@ -250,6 +251,10 @@ func main() {
 			}
 		}
 	})
+
+	// 200 replay for the loadbalancer
+	r.GET("/", func(_ *gin.Context) {})
+
 	r.Run("0.0.0.0:8080")
 }
 

--- a/main.go
+++ b/main.go
@@ -175,7 +175,7 @@ func main() {
 	githubClient := createGitHubClient(conf)
 	r := gin.Default()
 
-	r.POST("/incoming", func(context *gin.Context) {
+	r.POST("/", func(context *gin.Context) {
 		payload, err := github.ValidatePayload(context.Request, conf.githubSecret)
 
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -250,7 +250,7 @@ func main() {
 			}
 		}
 	})
-	r.Run("0.0.0.0:8083")
+	r.Run("0.0.0.0:8080")
 }
 
 func parsePullRequest(conf *config, action string, pr *github.PullRequestEvent) []buildOptions {


### PR DESCRIPTION
* Listen for the hook in root instead of incoming
As the tool will have a dedicated domain when deployed in the new infra.


* Add missing dependencies and initialization to the image
The image was missing:
    * openssh
    * SSH client initialization
    * release tool dependencies (pyyaml)
    * release tool in path

* Commented out in docker-compose file how the SSH keys are expected to be
mounted in the container.