### PR TITLE
[pipeline] Redefine locally .export_docker_vars

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,13 @@ include:
   - project: 'Northern.tech/Mender/mendertesting'
     file: '.gitlab-ci-github-status-updates.yml'
 
+# Function ported from template gitlab-ci-check-docker-build
+.export_docker_vars: &export_docker_vars |
+  export DOCKER_BUILD_TAG=${CI_COMMIT_REF_SLUG:-local}
+  export DOCKER_BUILD_SERVICE_IMAGE=${DOCKER_REPOSITORY}:${DOCKER_BUILD_TAG}
+  export DOCKER_PUBLISH_TAG=${CI_COMMIT_REF_NAME}
+  export DOCKER_PUBLISH_COMMIT_TAG=${CI_COMMIT_REF_NAME}_${CI_COMMIT_SHA}
+
 deploy:production:
   stage: publish
   only:


### PR DESCRIPTION
It seems like these functions don't get exposed out of the templates as
expected.