### PR TITLE
QA-201: Vendor dependabot PR's

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
 
+	"github.com/google/go-github/v28/github"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -69,4 +72,86 @@ func getListOfVersionedRepositories(inVersion string) ([]string, error) {
 	}
 
 	return strings.Split(strings.TrimSpace(string(output)), "\n"), nil
+}
+
+func validDependabotPR(pr *github.PullRequestEvent) bool {
+	return pr.GetAction() == "opened" && pr.GetSender().GetLogin() == "dependabot[bot]"
+}
+
+func maybeVendorDependabotPR(pr *github.PullRequestEvent) error {
+	if !validDependabotPR(pr) {
+		log.Debugf("Not a valid dependabot PR (%s:%s), ignoring...\n", pr.GetSender().GetLogin(), pr.GetAction())
+		return nil
+	}
+
+	branchName := pr.GetPullRequest().GetHead().GetRef()
+	if branchName == "" {
+		return fmt.Errorf("No Head set in the PR: %v", pr)
+	}
+
+	repo := pr.GetRepo().GetName()
+	if repo == "" {
+		return fmt.Errorf("No repository name found in PR: %v", pr)
+	}
+
+	tmpdir, err := ioutil.TempDir("", repo)
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpdir)
+
+	cmd := exec.Command("git", "clone", "--single-branch", "--branch", branchName, "git@github.com:mendersoftware/"+repo+".git")
+	cmd.Dir = tmpdir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v returned error: %s: %s", cmd.Args, out, err.Error())
+	}
+
+	cmdDir := tmpdir + "/" + repo
+
+	cmd = exec.Command("go", "mod", "tidy", "-v")
+	cmd.Dir = cmdDir
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v returned error: %s: %s", cmd.Args, out, err.Error())
+	}
+
+	cmd = exec.Command("go", "mod", "vendor", "-v")
+	cmd.Dir = cmdDir
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v returned error: %s: %s", cmd.Args, out, err.Error())
+	}
+
+	cmd = exec.Command("go", "mod", "verify")
+	cmd.Dir = cmdDir
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v returned error: %s: %s", cmd.Args, out, err.Error())
+	}
+
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = cmdDir
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v returned error: %s: %s", cmd.Args, out, err.Error())
+	}
+
+	cmd = exec.Command("git", "commit", "--amend", "--no-edit")
+	cmd.Dir = cmdDir
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v returned error: %s: %s", cmd.Args, out, err.Error())
+	}
+
+	cmd = exec.Command("git", "push", "--force")
+	cmd.Dir = cmdDir
+	out, err = cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v returned error: %s: %s", cmd.Args, out, err.Error())
+	}
+	log.Info("Successfully vendored Dependabot PR")
+
+	return nil
+
 }

--- a/main.go
+++ b/main.go
@@ -220,6 +220,11 @@ func main() {
 
 			// make sure we only parse one pr at a time, since we use git
 			mutex.Lock()
+
+			if err = maybeVendorDependabotPR(pr); err != nil {
+				log.Errorf("maybeVendorDependabotPR: %v", err)
+			}
+
 			builds := parsePullRequest(conf, action, pr)
 
 			// First check if the PR has been merged. If so, stop


### PR DESCRIPTION
Since Github's Dependabot does not support vendoring in Go, a manual step has to
be applied after a PR is opened with a dependency upgrade.

This commit will add the functionality, by having the bot fetch the remote
branch, vendor and tidy the repository, and push the new commit.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>