### PR TITLE
Select the correct poky branch on related yocto repos

### DIFF
--- a/main.go
+++ b/main.go
@@ -1033,6 +1033,8 @@ func getBuildParameters(conf *config, build *buildOptions) ([]*gitlab.PipelineVa
 	// is master, in which case we rely on the default.
 	if build.repo == "meta-mender" && build.baseBranch != "master" {
 		buildParameters = append(buildParameters, &gitlab.PipelineVariable{Key: repoToBuildParameter("poky"), Value: build.baseBranch})
+		buildParameters = append(buildParameters, &gitlab.PipelineVariable{Key: repoToBuildParameter("meta-openembedded"), Value: build.baseBranch})
+		buildParameters = append(buildParameters, &gitlab.PipelineVariable{Key: repoToBuildParameter("meta-raspberrypi"), Value: build.baseBranch})
 	}
 
 	// set the rest of the jenkins build parameters


### PR DESCRIPTION
From now on, we use meta-openembedded in the tests, so it is important
to set it to the right branch. Once we are on it, set meta-raspberrypi
too to be future ready.