### PR TITLE
Re-enable meta-mender builds on PR's

### DIFF
--- a/main.go
+++ b/main.go
@@ -256,7 +256,7 @@ func main() {
 
 			for idx, build := range builds {
 				log.Infof("%d: "+spew.Sdump(build)+"\n", idx+1)
-				if build.repo == "meta-mender" && build.baseBranch != "master-next" {
+				if build.repo == "meta-mender" && build.baseBranch == "master-next" {
 					log.Info("Skipping build for meta-mender:master-next")
 					continue
 				}

--- a/main.go
+++ b/main.go
@@ -257,7 +257,7 @@ func main() {
 			for idx, build := range builds {
 				log.Infof("%d: "+spew.Sdump(build)+"\n", idx+1)
 				if build.repo == "meta-mender" && build.baseBranch == "master-next" {
-					log.Info("Skipping build for meta-mender:master-next")
+					log.Info("Skipping build targeting meta-mender:master-next")
 					continue
 				}
 				err = triggerBuild(conf, &build, pr)


### PR DESCRIPTION
If I'm not mistaken, there is a slight logic error here: https://github.com/mendersoftware/integration-test-runner/pull/54/commits/f4b4cc504e53eba967e94a26c9ab5f375ccd2358

Second commit is optional. I just liked the sound better :)