### PR TITLE
Sync repos configurable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,9 +8,7 @@ FROM golang:1.14-alpine3.11
 EXPOSE 8080
 RUN apk add git openssh python3 py3-pip
 RUN pip3 install --upgrade pyyaml
-RUN mkdir -p /root/.ssh/ && \
-    git config --global user.name "Mender Root" && \
-    git config --global user.email root@mender-jenkins.mender.io
+RUN mkdir -p /root/.ssh
 RUN git clone https://github.com/mendersoftware/integration.git /integration
 ENV INTEGRATION_DIRECTORY="/integration/"
 ENV PATH="/integration/extra:${PATH}"

--- a/README.md
+++ b/README.md
@@ -1,5 +1,25 @@
 # integration test runner bot
 
+## Main features
+
+### `mender-qa` Pipeline run
+
+Set `WATCH_REPOS_PIPELINE` for the list of repositories for which to run
+`mender-qa` Pipeline. See source code for defaults.
+
+This is a Mender specific feature.
+
+### GitHub -> GitLab sync
+
+Set `WATCH_REPOS_SYNC` for the list of repositories for which to do
+GitHub->Gitlab git branches sync. Default is a list of the Mender Enterprise
+repositories.
+
+### GitLab PR branches
+
+For all repositories in the organization, a pr_XXX branch will be created in
+GitLab for every pull/XXX PR from GitHub.
+
 ## Infrastructure
 It's currently hosted on `company-websites` GKE Kubernetes cluster. The cluster in still in POC phase, so, CD is simplified to not have a lot of time wasted if the POC won't go live.
 

--- a/entrypoint
+++ b/entrypoint
@@ -1,5 +1,8 @@
 #!/bin/sh
 
+git config --global user.name ${GIT_CONFIG_USER_NAME-Mender Root}
+git config --global user.email ${GIT_CONFIG_USER_EMAIL-root@mender-jenkins.mender.io}
+
 ssh-keyscan github.com >> /root/.ssh/known_hosts
 ssh-keyscan gitlab.com >> /root/.ssh/known_hosts
 


### PR DESCRIPTION
* Configurable list of repos for which to do GitHub->GitLab sync
Rework a bit the config to allow for a configurable list of repositories
to sync via env variable WATCH_REPOS_SYNC.

* Make Git config user/email configurable via env variables
These are only required for operations that perform "git commit", like
dependabot's commits amend.

* Add some minimal documentation on the three main features

* Extend the sync and PR branches features to CFEngine
Namely, map GitHub organizations to GitLab groups, so that we can use
these features on both organizations.