### PR TITLE
deleteStaleGitlabPRBranch: fix "Failed to delete the stale PR branch"

### DIFF
--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -80,7 +80,7 @@ func deleteStaleGitlabPRBranch(log *logrus.Entry, pr *github.PullRequestEvent, c
 		return nil
 	}
 	repoName := pr.GetRepo().GetName()
-	repoOrg := pr.GetRepo().GetOrganization().GetLogin()
+	repoOrg := pr.GetOrganization().GetLogin()
 
 	tmpdir, err := ioutil.TempDir("", repoName)
 	if err != nil {

--- a/util.go
+++ b/util.go
@@ -24,7 +24,7 @@ func getRemoteURLGitLab(org, repo string) (string, error) {
 	// By default, the GitLab project is Northern.tech/<group>/<repo>
 	group, ok := gitHubOrganizationToGitLabGroup[org]
 	if !ok {
-		return "", fmt.Errorf("Unrecognized organization %s", org)
+		return "", fmt.Errorf("Unrecognized organization %q", org)
 	}
 	remoteURL := "git@gitlab.com:Northern.tech/" + group + "/" + repo
 


### PR DESCRIPTION
We want to access the org of the PR, not the org of the repo...

Quoted also the getRemoteURLGitLab output to easily identify a blank org
variable.