### PR TITLE
[cherrypicks] Accept Changelog entries with no space after colon

### DIFF
--- a/cherrypicks.go
+++ b/cherrypicks.go
@@ -90,7 +90,7 @@ func suggestCherryPicks(log *logrus.Entry, pr *github.PullRequestEvent, githubCl
 
 	// count the number commits with Changelog entries
 	baseSHA := pr.GetPullRequest().GetBase().GetSHA()
-	countCmd := exec.Command("sh", "-c", "git log "+baseSHA+"...pr_"+prNumber+" | grep -i -e \"^    Changelog: \" | grep -v -i -e \"^    Changelog: *none\" | wc -l")
+	countCmd := exec.Command("sh", "-c", "git log "+baseSHA+"...pr_"+prNumber+" | grep -i -e \"^    Changelog:\" | grep -v -i -e \"^    Changelog: *none\" | wc -l")
 	countCmd.Dir = tmpdir
 	out, err = countCmd.CombinedOutput()
 	if err != nil {

--- a/cherrypicks_test.go
+++ b/cherrypicks_test.go
@@ -114,6 +114,29 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 `),
 			},
 		},
+		"cherry picks, changelogs, syntax with no space": {
+			pr: &github.PullRequestEvent{
+				Action: github.String("closed"),
+				Number: github.Int(29),
+				PullRequest: &github.PullRequest{
+					Base: &github.PullRequestBranch{
+						Ref: github.String("master"),
+						SHA: github.String("c138b0256ec874bcd16d4cae4b598b8615b2d415"),
+					},
+					Merged: github.Bool(true),
+				},
+				Repo: &github.Repository{
+					Name: github.String("mender-connect"),
+				},
+			},
+			comment: &github.IssueComment{
+				Body: github.String(`
+Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
+1.1.x (release 2.7.x)
+1.0.x (release 2.6.x)
+`),
+			},
+		},
 	}
 
 	tmpdir, err := ioutil.TempDir("", "*")

--- a/cherrypicks_test.go
+++ b/cherrypicks_test.go
@@ -85,8 +85,8 @@ func TestSuggestCherryPicks(t *testing.T) {
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
+1.4.x (release 2.7.x)
 1.3.x (release 2.6.x)
-1.2.x (release 2.5.x)
 1.1.x (release 2.4.x)
 `),
 			},
@@ -109,6 +109,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
+1.1.x (release 2.7.x)
 1.0.x (release 2.6.x)
 `),
 			},


### PR DESCRIPTION
And fix existing tests.

This fix will catch the next iteration of a changelog like the one at https://github.com/mendersoftware/mender-connect/pull/29