### PR TITLE
Only comment once on a PR

### DIFF
--- a/client/github/client.go
+++ b/client/github/client.go
@@ -13,6 +13,7 @@ type Client interface {
 	IsOrganizationMember(ctx context.Context, org string, user string) bool
 	CreatePullRequest(ctx context.Context, org string, repo string, pr *github.NewPullRequest) (*github.PullRequest, error)
 	GetPullRequest(ctx context.Context, org string, repo string, pr int) (*github.PullRequest, error)
+	ListComments(ctx context.Context, owner, repo string, number int, opts *github.IssueListCommentsOptions) ([]*github.IssueComment, error)
 }
 
 type gitHubClient struct {
@@ -50,4 +51,9 @@ func (c *gitHubClient) CreatePullRequest(ctx context.Context, org string, repo s
 func (c *gitHubClient) GetPullRequest(ctx context.Context, org string, repo string, pr int) (*github.PullRequest, error) {
 	newPR, _, err := c.client.PullRequests.Get(ctx, org, repo, pr)
 	return newPR, err
+}
+
+func (c *gitHubClient) ListComments(ctx context.Context, owner, repo string, number int, opts *github.IssueListCommentsOptions) ([]*github.IssueComment, error) {
+	comments, _, err := c.client.Issues.ListComments(ctx, owner, repo, number, opts)
+	return comments, err
 }

--- a/client/github/mocks/Client.go
+++ b/client/github/mocks/Client.go
@@ -87,3 +87,26 @@ func (_m *Client) IsOrganizationMember(ctx context.Context, org string, user str
 
 	return r0
 }
+
+// ListComments provides a mock function with given fields: ctx, owner, repo, number, opts
+func (_m *Client) ListComments(ctx context.Context, owner string, repo string, number int, opts *github.IssueListCommentsOptions) ([]*github.IssueComment, error) {
+	ret := _m.Called(ctx, owner, repo, number, opts)
+
+	var r0 []*github.IssueComment
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, int, *github.IssueListCommentsOptions) []*github.IssueComment); ok {
+		r0 = rf(ctx, owner, repo, number, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*github.IssueComment)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, int, *github.IssueListCommentsOptions) error); ok {
+		r1 = rf(ctx, owner, repo, number, opts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}

--- a/main_pullrequest_test.go
+++ b/main_pullrequest_test.go
@@ -1,0 +1,92 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/go-github/v28/github"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+
+	mock_github "github.com/mendersoftware/integration-test-runner/client/github/mocks"
+)
+
+func TestBotHasAlreadyCommentedOnPR(t *testing.T) {
+	type returnValues struct {
+		issueComments []*github.IssueComment
+		error         error
+	}
+	commentString := github.String(", Let me know if you want to start the integration pipeline by mentioning me and the command \"")
+	testCases := map[string]struct {
+		pr             *github.PullRequestEvent
+		expectedResult bool
+		returnVals     returnValues
+	}{
+		"Bot has not commented": {
+			pr: &github.PullRequestEvent{
+				PullRequest: &github.PullRequest{
+					Merged: github.Bool(false),
+				},
+				Repo: &github.Repository{
+					Name: github.String("I am not the bot"),
+					Owner: &github.User{
+						Name: github.String("mendersoftware"),
+					},
+				},
+				Number: github.Int(6),
+			},
+			returnVals: returnValues{
+				issueComments: nil,
+				error:         errors.New("Failed to retrieve the comments"),
+			},
+			expectedResult: false,
+		},
+		"Bot has commented": {
+			pr: &github.PullRequestEvent{
+				PullRequest: &github.PullRequest{
+					Merged: github.Bool(false),
+				},
+				Repo: &github.Repository{
+					Name: commentString,
+					Owner: &github.User{
+						Name: github.String("mendersoftware"),
+					},
+				},
+				Number: github.Int(6),
+			},
+			returnVals: returnValues{
+				issueComments: []*github.IssueComment{
+					&github.IssueComment{
+						Body: commentString,
+					},
+				},
+				error: nil,
+			},
+			expectedResult: true,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			mclient := &mock_github.Client{}
+			defer mclient.AssertExpectations(t)
+
+			mclient.On("ListComments",
+				mock.MatchedBy(func(ctx context.Context) bool {
+					return true
+				}),
+				*tc.pr.Repo.Owner.Name,
+				*tc.pr.Repo.Name,
+				*tc.pr.Number,
+				mock.MatchedBy(func(*github.IssueListCommentsOptions) bool {
+					return true
+				}),
+			).Return(tc.returnVals.issueComments, tc.returnVals.error)
+
+			log := logrus.NewEntry(logrus.StandardLogger())
+			assert.Equal(t, tc.expectedResult, botHasAlreadyCommentedOnPR(log, mclient, tc.pr, *commentString))
+		})
+	}
+}


### PR DESCRIPTION
The bot can be kinda noisy if there are a lot of pushes to a PR.

This makes sure that if there is a comment from the bot already, there is no new
comment posted.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>