### PR TITLE
Fix: Use the hardcoded github organization as the repo owner

### DIFF
--- a/main_pullrequest.go
+++ b/main_pullrequest.go
@@ -97,7 +97,7 @@ func processGitHubPullRequest(ctx *gin.Context, pr *github.PullRequestEvent, git
 func botHasAlreadyCommentedOnPR(log *logrus.Entry, githubClient clientgithub.Client, pr *github.PullRequestEvent, botComment string) bool {
 	comments, err := githubClient.ListComments(
 		context.Background(),
-		pr.GetRepo().GetOwner().GetName(),
+		githubOrganization,
 		pr.GetRepo().GetName(),
 		pr.GetNumber(),
 		&github.IssueListCommentsOptions{


### PR DESCRIPTION
The retrieval of the repo owner does not work, also, everywhere else in code
defaults to githubOrganization, which is hardcoded to 'mendersoftware'.

This should fix the error the bot is currently having, see the logs:

```
2021-04-27 16:48:14.000 CEST
Failed to list the comments on PR: mender/741, err: 'GET https://api.github.com/repos//mender/issues/741/comments?direction=asc&sort=created: 404 Not Found []'
```

And note the missing 'mendersoftware' specification.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>