### PR TITLE
[pullreq_pipeline] Do not create branches for PRs coming from branches

### DIFF
--- a/main_pullrequest.go
+++ b/main_pullrequest.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	"strconv"
 	"strings"
 
 	"github.com/gin-gonic/gin"
@@ -25,7 +24,7 @@ func processGitHubPullRequest(ctx *gin.Context, pr *github.PullRequestEvent, git
 
 	// To run component's Pipeline create a branch in GitLab, regardless of the PR
 	// coming from an organization member or not (equivalent to the old Travis tests)
-	if err := createPullRequestBranch(log, *pr.Organization.Login, *pr.Repo.Name, strconv.Itoa(pr.GetNumber()), action, conf); err != nil {
+	if err := createPullRequestBranch(log, pr, conf); err != nil {
 		log.Errorf("Could not create PR branch: %s", err.Error())
 	}
 

--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -5,18 +5,24 @@ import (
 	"io/ioutil"
 	"os"
 	"os/exec"
+	"strconv"
 
 	"github.com/google/go-github/v28/github"
 	"github.com/sirupsen/logrus"
 )
 
-func createPullRequestBranch(log *logrus.Entry, org, repo, pr, action string, conf *config) error {
+func createPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, conf *config) error {
 
+	action := pr.GetAction()
 	if action != "opened" && action != "edited" && action != "reopened" &&
 		action != "synchronize" && action != "ready_for_review" {
 		log.Infof("Action %s, ignoring", action)
 		return nil
 	}
+
+	repo := pr.GetRepo().GetName()
+	org := pr.GetOrganization().GetLogin()
+	prNum := strconv.Itoa(pr.GetNumber())
 
 	tmpdir, err := ioutil.TempDir("", repo)
 	if err != nil {
@@ -51,8 +57,8 @@ func createPullRequestBranch(log *logrus.Entry, org, repo, pr, action string, co
 		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
-	prBranchName := "pr_" + pr
-	gitcmd = exec.Command("git", "fetch", "github", "pull/"+pr+"/head:"+prBranchName)
+	prBranchName := "pr_" + prNum
+	gitcmd = exec.Command("git", "fetch", "github", "pull/"+prNum+"/head:"+prBranchName)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {

--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -16,7 +16,13 @@ func createPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, con
 	action := pr.GetAction()
 	if action != "opened" && action != "edited" && action != "reopened" &&
 		action != "synchronize" && action != "ready_for_review" {
-		log.Infof("Action %s, ignoring", action)
+		log.Infof("createPullRequestBranch: Action %s, ignoring", action)
+		return nil
+	}
+
+	prHeadFork := pr.GetPullRequest().GetHead().GetUser().GetLogin()
+	if prHeadFork == "mendersoftware" {
+		log.Debug("createPullRequestBranch: PR head is a branch in mendersoftware, ignoring")
 		return nil
 	}
 


### PR DESCRIPTION
The functionality is meant to do branches from our forks, but some times
we do have PRs coming from actual branches, ending up with duplicate
pipelines running...
