### PR TITLE
[QA-318] Default to syncing ALL repositories when processing push webhooks

### DIFF
--- a/main.go
+++ b/main.go
@@ -212,10 +212,12 @@ func main() {
 		payload, err := github.ValidatePayload(context.Request, conf.githubSecret)
 		if err != nil {
 			logrus.Warnln("payload failed to validate, ignoring.")
+			context.Status(http.StatusForbidden)
 			return
 		}
 		context.Set("delivery", github.DeliveryID(context.Request))
 		go processGitHubWebhookRequest(context, payload, githubClient, conf)
+		context.Status(http.StatusAccepted)
 	})
 
 	// 200 replay for the loadbalancer

--- a/main_push.go
+++ b/main_push.go
@@ -16,15 +16,9 @@ func processGitHubPush(ctx *gin.Context, push *github.PushEvent, githubClient cl
 
 	log.Debugf("Got push event :: repo %s :: ref %s", repoName, refName)
 
-	for _, repo := range conf.watchRepositoriesGitLabSync {
-		if repoName == repo {
-			err := syncRemoteRef(log, repoOrg, repoName, refName, conf)
-			if err != nil {
-				log.Errorf("Could not sync branch: %s", err.Error())
-			}
-			return err
-		}
+	err := syncRemoteRef(log, repoOrg, repoName, refName, conf)
+	if err != nil {
+		log.Errorf("Could not sync branch: %s", err.Error())
 	}
-
-	return nil
+	return err
 }


### PR DESCRIPTION
TODO (before merge):
 - [ ] Remove GitLab integrations
 - [ ] Remove GitHub webhook calling GitLab mirror resync