### PR TITLE
Pull Request sync add gitlab CI_EXTERNAL_* environment

### DIFF
--- a/main_pullrequest.go
+++ b/main_pullrequest.go
@@ -24,8 +24,8 @@ func processGitHubPullRequest(ctx *gin.Context, pr *github.PullRequestEvent, git
 
 	// To run component's Pipeline create a branch in GitLab, regardless of the PR
 	// coming from an organization member or not (equivalent to the old Travis tests)
-	if err := createPullRequestBranch(log, pr, conf); err != nil {
-		log.Errorf("Could not create PR branch: %s", err.Error())
+	if err := syncPullRequest(log, pr, conf); err != nil {
+		log.Errorf("Could not sync PR: %s", err.Error())
 	}
 
 	// Delete merged pr branches in GitLab

--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -11,24 +11,35 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func createPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, conf *config) error {
+func getGitlabBranch(pr *github.PullRequestEvent) string {
+	prHead := pr.GetPullRequest().GetHead()
+	if prHead.GetUser().GetLogin() == "mendersoftware" {
+		return prHead.GetRef()
+	}
+	return "pr_" + strconv.Itoa(pr.GetNumber())
+}
+
+func syncPullRequest(log *logrus.Entry, pr *github.PullRequestEvent, conf *config) error {
 
 	action := pr.GetAction()
 	if action != "opened" && action != "edited" && action != "reopened" &&
 		action != "synchronize" && action != "ready_for_review" {
-		log.Infof("createPullRequestBranch: Action %s, ignoring", action)
-		return nil
-	}
-
-	prHeadFork := pr.GetPullRequest().GetHead().GetUser().GetLogin()
-	if prHeadFork == "mendersoftware" {
-		log.Debug("createPullRequestBranch: PR head is a branch in mendersoftware, ignoring")
+		log.Infof("syncPullRequest: Action %s, ignoring", action)
 		return nil
 	}
 
 	repo := pr.GetRepo().GetName()
 	org := pr.GetOrganization().GetLogin()
 	prNum := strconv.Itoa(pr.GetNumber())
+	req := pr.GetPullRequest()
+	base := req.GetBase()
+	targetRepo := base.GetRepo().GetFullName()
+	targetBranch := base.GetRef()
+	targetSHA := base.GetSHA()
+	head := req.GetHead()
+	sourceRepo := head.GetRepo().GetFullName()
+	sourceBranch := head.GetRef()
+	sourceSHA := head.GetSHA()
 
 	tmpdir, err := ioutil.TempDir("", repo)
 	if err != nil {
@@ -63,15 +74,26 @@ func createPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, con
 		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
-	prBranchName := "pr_" + prNum
+	prBranchName := getGitlabBranch(pr)
 	gitcmd = git.Command("fetch", "github", "pull/"+prNum+"/head:"+prBranchName)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
-
-	gitcmd = git.Command("push", "-f", "--set-upstream", "gitlab", prBranchName)
+	gitcmd = git.Command(
+		"push", "-f",
+		// The following push options are simulating gitlab repository mirroring
+		// and are for resolving coverage reports PRs.
+		"-o", `ci.variable="CI_EXTERNAL_PULL_REQUEST_IID=`+prNum+`"`,
+		"-o", `ci.variable="CI_EXTERNAL_PULL_REQUEST_SOURCE_REPOSITORY=`+sourceRepo+`"`,
+		"-o", `ci.variable="CI_EXTERNAL_PULL_REQUEST_TARGET_REPOSITORY=`+targetRepo+`"`,
+		"-o", `ci.variable="CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME=`+sourceBranch+`"`,
+		"-o", `ci.variable="CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME=`+targetBranch+`"`,
+		"-o", `ci.variable="CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA=`+sourceSHA+`"`,
+		"-o", `ci.variable="CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_SHA=`+targetSHA+`"`,
+		"--set-upstream", "gitlab", prBranchName,
+	)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {
@@ -93,6 +115,7 @@ func deleteStaleGitlabPRBranch(log *logrus.Entry, pr *github.PullRequestEvent, c
 	}
 	repoName := pr.GetRepo().GetName()
 	repoOrg := pr.GetOrganization().GetLogin()
+	prBranchName := getGitlabBranch(pr)
 
 	tmpdir, err := ioutil.TempDir("", repoName)
 	if err != nil {
@@ -126,7 +149,7 @@ func deleteStaleGitlabPRBranch(log *logrus.Entry, pr *github.PullRequestEvent, c
 		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
-	gitcmd = git.Command("push", "gitlab", "--delete", fmt.Sprintf("pr_%d", pr.GetNumber()))
+	gitcmd = git.Command("push", "gitlab", "--delete", prBranchName)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {

--- a/tests/tests/test_github_webhooks.py
+++ b/tests/tests/test_github_webhooks.py
@@ -43,7 +43,17 @@ def test_pull_request_opened(integration_test_runner_url):
         "git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/workflows.git",
         "git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/workflows",
         "git.Run: /usr/bin/git fetch github pull/140/head:pr_140",
-        "git.Run: /usr/bin/git push -f --set-upstream gitlab pr_140",
+        'git.Run: /usr/bin/git push -f -o '
+      +  'ci.variable="CI_EXTERNAL_PULL_REQUEST_IID=140" -o '
+      +  'ci.variable="CI_EXTERNAL_PULL_REQUEST_SOURCE_REPOSITORY=tranchitella/workflows" '
+      +  '-o '
+      +  'ci.variable="CI_EXTERNAL_PULL_REQUEST_TARGET_REPOSITORY=mendersoftware/workflows" '
+      +  '-o ci.variable="CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME=men-4705" -o '
+      +  'ci.variable="CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME=master" -o '
+      +  'ci.variable="CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA=7b099b84cb50df18847027b0afa16820eab850d9" '
+      +  '-o '
+      +  'ci.variable="CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_SHA=70ab90b3932d3d008ebee56d6cfe4f3329d5ee7b" '
+      +  '--set-upstream gitlab pr_140',
         "info:Created branch: workflows:pr_140",
         "info:Pipeline is expected to start automatically",
         "debug:deleteStaleGitlabPRBranch: PR not closed, therefore not stopping it's pipeline",
@@ -74,7 +84,7 @@ def test_pull_request_closed(integration_test_runner_url):
     res = requests.get(integration_test_runner_url + "/logs")
     assert res.status_code == 200
     assert res.json() == [
-        "info:createPullRequestBranch: Action closed, ignoring",
+        "info:syncPullRequest: Action closed, ignoring",
         "git.Run: /usr/bin/git init .",
         "git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/workflows",
         "git.Run: /usr/bin/git fetch gitlab",


### PR DESCRIPTION
This pull request will sync ALL pull requests to gitlab by setting ci
variables as push options. However, if the pr is comming from the
upstream repository, the corresponding gitlab branch is force-pushed.

FYI @tranchitella @lluiscampos this PR addresses the coverage reports not referring to the PR base.