### PR TITLE
PRs: Mimick gitlab repository mirroring environment vars

### DIFF
--- a/main.go
+++ b/main.go
@@ -230,6 +230,7 @@ func doMain() {
 
 	githubClient := clientgithub.NewGitHubClient(conf.githubToken, conf.dryRunMode)
 	r := gin.Default()
+	r.Use(gin.Recovery())
 
 	// webhook for GitHub
 	r.POST("/", func(context *gin.Context) {

--- a/menderqa_pipeline.go
+++ b/menderqa_pipeline.go
@@ -74,7 +74,7 @@ func getBuilds(log *logrus.Entry, conf *config, pr *github.PullRequestEvent) []b
 
 			default:
 				var err error
-				integrationsToTest := []string{}
+				var integrationsToTest []string
 
 				if integrationsToTest, err = getIntegrationVersionsUsingMicroservice(log, repo, baseBranch, conf); err != nil {
 					log.Errorf("failed to get related microservices for repo: %s version: %s, failed with: %s\n", repo, baseBranch, err.Error())

--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -34,7 +34,7 @@ func startPRPipeline(log *logrus.Entry, ref string, event *github.PullRequestEve
 	}
 	repoHostURI := strings.SplitN(repoURL, ":", 2)
 	if len(repoHostURI) != 2 {
-		return fmt.Errorf("invalid GitLab URL '%s': failed to start gitlab pipeline", repoURL)
+		return fmt.Errorf("invalid GitLab URL '%s': failed to start GitLab pipeline", repoURL)
 	}
 	gitlabPath := repoHostURI[1]
 
@@ -73,19 +73,6 @@ func startPRPipeline(log *logrus.Entry, ref string, event *github.PullRequestEve
 }
 
 func syncPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, conf *config) (string, error) {
-
-	action := pr.GetAction()
-	if action != "opened" && action != "edited" && action != "reopened" &&
-		action != "synchronize" && action != "ready_for_review" {
-		log.Infof("createPullRequestBranch: Action %s, ignoring", action)
-		return "", nil
-	}
-
-	prHeadFork := pr.GetPullRequest().GetHead().GetUser().GetLogin()
-	if prHeadFork == "mendersoftware" {
-		log.Debug("createPullRequestBranch: PR head is a branch in mendersoftware, ignoring")
-		return "", nil
-	}
 
 	repo := pr.GetRepo().GetName()
 	org := pr.GetOrganization().GetLogin()

--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -5,25 +5,86 @@ import (
 	"io/ioutil"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/google/go-github/v28/github"
+	clientgitlab "github.com/mendersoftware/integration-test-runner/client/gitlab"
 	"github.com/mendersoftware/integration-test-runner/git"
 	"github.com/sirupsen/logrus"
+	"github.com/xanzy/go-gitlab"
 )
 
-func createPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, conf *config) error {
+func startPRPipeline(log *logrus.Entry, ref string, event *github.PullRequestEvent, conf *config) error {
+	client, err := clientgitlab.NewGitLabClient(
+		conf.gitlabToken,
+		conf.gitlabBaseURL,
+		conf.dryRunMode,
+	)
+	if err != nil {
+		return err
+	}
+	pr := event.GetPullRequest()
+	org := event.GetOrganization().GetLogin()
+	head := pr.GetHead()
+	base := pr.GetBase()
+	repo := event.GetRepo()
+	repoURL, err := getRemoteURLGitLab(org, repo.GetName())
+	if err != nil {
+		return err
+	}
+	repoHostURI := strings.SplitN(repoURL, ":", 2)
+	if len(repoHostURI) != 2 {
+		return fmt.Errorf("invalid GitLab URL '%s': failed to start gitlab pipeline", repoURL)
+	}
+	gitlabPath := repoHostURI[1]
+
+	pipeline, err := client.CreatePipeline(gitlabPath, &gitlab.CreatePipelineOptions{
+		Ref: &ref,
+		Variables: []*gitlab.PipelineVariable{{
+			Key:   "CI_EXTERNAL_PULL_REQUEST_IID",
+			Value: strconv.Itoa(event.GetNumber()),
+		}, {
+			Key:   "CI_EXTERNAL_PULL_REQUEST_SOURCE_REPOSITORY",
+			Value: head.GetRepo().GetFullName(),
+		}, {
+			Key:   "CI_EXTERNAL_PULL_REQUEST_TARGET_REPOSITORY",
+			Value: repo.GetFullName(),
+		}, {
+			Key:   "CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME",
+			Value: head.GetRef(),
+		}, {
+			Key:   "CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA",
+			Value: head.GetSHA(),
+		}, {
+			Key:   "CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME",
+			Value: base.GetRef(),
+		}, {
+			Key:   "CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_SHA",
+			Value: base.GetSHA(),
+		}},
+	})
+	if err != nil {
+		return err
+	} else {
+		log.Debugf("started pipeline for PR: %s", pipeline.WebURL)
+	}
+
+	return nil
+}
+
+func syncPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, conf *config) (string, error) {
 
 	action := pr.GetAction()
 	if action != "opened" && action != "edited" && action != "reopened" &&
 		action != "synchronize" && action != "ready_for_review" {
 		log.Infof("createPullRequestBranch: Action %s, ignoring", action)
-		return nil
+		return "", nil
 	}
 
 	prHeadFork := pr.GetPullRequest().GetHead().GetUser().GetLogin()
 	if prHeadFork == "mendersoftware" {
 		log.Debug("createPullRequestBranch: PR head is a branch in mendersoftware, ignoring")
-		return nil
+		return "", nil
 	}
 
 	repo := pr.GetRepo().GetName()
@@ -32,7 +93,7 @@ func createPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, con
 
 	tmpdir, err := ioutil.TempDir("", repo)
 	if err != nil {
-		return err
+		return "", err
 	}
 	defer os.RemoveAll(tmpdir)
 
@@ -40,7 +101,7 @@ func createPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, con
 	gitcmd.Dir = tmpdir
 	out, err := gitcmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+		return "", fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
 	repoURL := getRemoteURLGitHub(conf.githubProtocol, githubOrganization, repo)
@@ -48,19 +109,19 @@ func createPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, con
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+		return "", fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
 	remoteURL, err := getRemoteURLGitLab(org, repo)
 	if err != nil {
-		return fmt.Errorf("getRemoteURLGitLab returned error: %s", err.Error())
+		return "", fmt.Errorf("getRemoteURLGitLab returned error: %s", err.Error())
 	}
 
 	gitcmd = git.Command("remote", "add", "gitlab", remoteURL)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+		return "", fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
 	prBranchName := "pr_" + prNum
@@ -68,19 +129,19 @@ func createPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, con
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+		return "", fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
-	gitcmd = git.Command("push", "-f", "--set-upstream", "gitlab", prBranchName)
+	// Push but not don't trigger CI (yet)
+	gitcmd = git.Command("push", "-f", "-o", "ci.skip", "--set-upstream", "gitlab", prBranchName)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+		return "", fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
 	log.Infof("Created branch: %s:%s", repo, prBranchName)
-	log.Info("Pipeline is expected to start automatically")
-	return nil
+	return prBranchName, nil
 }
 
 func deleteStaleGitlabPRBranch(log *logrus.Entry, pr *github.PullRequestEvent, conf *config) error {

--- a/tests/tests/test_github_webhooks.py
+++ b/tests/tests/test_github_webhooks.py
@@ -39,15 +39,24 @@ def test_pull_request_opened(integration_test_runner_url):
     res = requests.get(integration_test_runner_url + "/logs")
     assert res.status_code == 200
     assert res.json() == [
+        "debug:Processing pull request action opened",
         "git.Run: /usr/bin/git init .",
         "git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/workflows.git",
         "git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/workflows",
         "git.Run: /usr/bin/git fetch github pull/140/head:pr_140",
-        "git.Run: /usr/bin/git push -f --set-upstream gitlab pr_140",
+        "git.Run: /usr/bin/git push -f -o ci.skip --set-upstream gitlab pr_140",
         "info:Created branch: workflows:pr_140",
-        "info:Pipeline is expected to start automatically",
-        "debug:deleteStaleGitlabPRBranch: PR not closed, therefore not stopping it's pipeline",
-        "info:Ignoring cherry-pick suggestions for action: opened, merged: false",
+        "gitlab.CreatePipeline: "
+        + "path=Northern.tech/Mender/workflows,"
+        + 'options={"ref":"pr_140","variables":'
+        + '[{"key":"CI_EXTERNAL_PULL_REQUEST_IID","value":"140"},'
+        + '{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_REPOSITORY","value":"tranchitella/workflows"},'
+        + '{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_REPOSITORY","value":"mendersoftware/workflows"},'
+        + '{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME","value":"men-4705"},'
+        + '{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA","value":"7b099b84cb50df18847027b0afa16820eab850d9"},'
+        + '{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME","value":"master"},'
+        + '{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_SHA","value":"70ab90b3932d3d008ebee56d6cfe4f3329d5ee7b"}]}',
+        "debug:started pipeline for PR: ",
         "github.IsOrganizationMember: org=mendersoftware,user=tranchitella",
         "debug:stopBuildsOfStalePRs: PR not closed, therefore not stopping it's pipeline",
         "info:Pull request event with action: opened",
@@ -74,7 +83,7 @@ def test_pull_request_closed(integration_test_runner_url):
     res = requests.get(integration_test_runner_url + "/logs")
     assert res.status_code == 200
     assert res.json() == [
-        "info:createPullRequestBranch: Action closed, ignoring",
+        "debug:Processing pull request action closed",
         "git.Run: /usr/bin/git init .",
         "git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/workflows",
         "git.Run: /usr/bin/git fetch gitlab",
@@ -128,7 +137,7 @@ def test_pull_request_closed(integration_test_runner_url):
         "info:Merged branch: opensource/workflows/master into enterprise/workflows/master in the Enterprise repo",
         'github.CreatePullRequest: org=mendersoftware,repo=workflows-enterprise,pr={"title":"[Bot] Improve logging","head":"mender-test-bot:mergeostoent_140","base":"master","body":"Original PR: https://github.com/mendersoftware/workflows/pull/140\\n\\nChangelog: none\\r\\n\\r\\nSigned-off-by: Fabio Tranchitella \\u003cfabio.tranchitella@northern.tech\\u003e","maintainer_can_modify":true}',
         "info:syncIfOSHasEnterpriseRepo: Created PR: 0 on Enterprise/workflows/master",
-        'debug:syncIfOSHasEnterpriseRepo: Created PR: id=666510619,number=140,title=Improve logging',
+        "debug:syncIfOSHasEnterpriseRepo: Created PR: id=666510619,number=140,title=Improve logging",
         "debug:Trying to @mention the user in the newly created PR",
         "debug:userName: tranchitella",
         'github.CreateComment: org=mendersoftware,repo=workflows-enterprise,number=0,comment={"body":"@tranchitella I have created a PR for you, ready to merge as soon as tests are passed"}',

--- a/tests/tests/test_github_webhooks.py
+++ b/tests/tests/test_github_webhooks.py
@@ -197,7 +197,7 @@ def test_issue_comment(integration_test_runner_url):
         ' pr: (string) (len=3) "109",\n'
         ' repo: (string) (len=13) "deviceconnect",\n'
         ' baseBranch: (string) (len=6) "master",\n'
-        ' commitSHA: (string) (len=40) "c52542074ffe1c60dfceccf1baedf49dc10cb643",\n'
+        ' commitSHA: (string) (len=40) "e49c29b57bdd8a0a0667cee4bf9463d8211169e0",\n'
         " makeQEMU: (bool) false\n}\n\n",
         "info:auditlogs version origin/master is being used in master",
         "info:create-artifact-worker version origin/master is being used in master",


### PR DESCRIPTION
This PR will explicitly start a new pipeline when is created or changes state (except for closing/merging), with the `CI_EXTERNAL_*` environment defined [here](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html#predefined-variables-for-external-pull-request-pipelines).