### PR TITLE
FIX: Remotes appearing in branchnames

### DIFF
--- a/cherrypicks_test.go
+++ b/cherrypicks_test.go
@@ -85,9 +85,9 @@ func TestSuggestCherryPicks(t *testing.T) {
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
+2.0.x (release 3.0.x)
 1.4.x (release 2.7.x)
 1.3.x (release 2.6.x)
-1.1.x (release 2.4.x)
 `),
 			},
 		},
@@ -109,6 +109,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
+1.2.x (release 3.0.x)
 1.1.x (release 2.7.x)
 1.0.x (release 2.6.x)
 `),
@@ -132,6 +133,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
+1.2.x (release 3.0.x)
 1.1.x (release 2.7.x)
 1.0.x (release 2.6.x)
 `),

--- a/menderqa_pipeline_helpers.go
+++ b/menderqa_pipeline_helpers.go
@@ -13,9 +13,15 @@ import (
 func getServiceRevisionFromIntegration(repo, baseBranch string, conf *config) (string, error) {
 	c := exec.Command("python3", "release_tool.py", "--version-of", repo, "--in-integration-version", baseBranch)
 	c.Dir = conf.integrationDirectory + "/extra/"
-	version, err := c.Output()
+	out, err := c.Output()
 	if err != nil {
-		err = fmt.Errorf("getServiceRevisionFromIntegration: Error: %v (%s)", err, version)
+		err = fmt.Errorf("getServiceRevisionFromIntegration: Error: %v (%s)", err, out)
+	}
+	version := string(out)
+
+	// remove the remote (ex: "`origin`/1.0.x")
+	if strings.Contains(version, "/") {
+		version = strings.SplitN(version, "/", 2)[1]
 	}
 	return strings.TrimSpace(string(version)), err
 }

--- a/tests/tests/test_github_webhooks.py
+++ b/tests/tests/test_github_webhooks.py
@@ -110,11 +110,13 @@ def test_pull_request_closed(integration_test_runner_url):
     assert res.json() == [
         "debug:Processing pull request action closed",
         "git.Run: /usr/bin/git init .",
-        "git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/workflows",
+        "git.Run: /usr/bin/git remote add gitlab "
+        "git@gitlab.com:Northern.tech/Mender/workflows",
         "git.Run: /usr/bin/git fetch gitlab",
         "git.Run: /usr/bin/git push gitlab --delete pr_140",
         "git.Run: /usr/bin/git init .",
-        "git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/workflows.git",
+        "git.Run: /usr/bin/git remote add github "
+        "git@github.com:/mendersoftware/workflows.git",
         "git.Run: /usr/bin/git fetch github master:local",
         "git.Run: /usr/bin/git fetch github pull/140/head:pr_140",
         "info:Found no changelog entries, ignoring cherry-pick suggestions",
@@ -123,49 +125,66 @@ def test_pull_request_closed(integration_test_runner_url):
         "git.Run: /usr/bin/git pull --rebase origin",
         "info:workflows/master is being used in the following integration: [master]",
         "info:the following integration branches: [master] are using workflows/master",
-        "info:auditlogs version origin/master is being used in master",
-        "info:create-artifact-worker version origin/master is being used in master",
-        "info:deployments version origin/master is being used in master",
-        "info:deployments-enterprise version origin/master is being used in master",
-        "info:deviceauth version origin/master is being used in master",
-        "info:deviceconfig version origin/master is being used in master",
-        "info:deviceconnect version origin/master is being used in master",
-        "info:gui version origin/master is being used in master",
-        "info:inventory version origin/master is being used in master",
-        "info:inventory-enterprise version origin/master is being used in master",
-        "info:mender version origin/master is being used in master",
-        "info:mender-artifact version origin/master is being used in master",
-        "info:mender-cli version origin/master is being used in master",
-        "info:mender-connect version origin/master is being used in master",
-        "info:mtls-ambassador version origin/master is being used in master",
-        "info:tenantadm version origin/master is being used in master",
-        "info:useradm version origin/master is being used in master",
-        "info:useradm-enterprise version origin/master is being used in master",
-        "info:workflows-enterprise version origin/master is being used in master",
-        'gitlab.ListProjectPipelines: path=Northern.tech/Mender/mender-qa,options={"status":"pending","username":"mender-test-bot"}',
-        'gitlab.ListProjectPipelines: path=Northern.tech/Mender/mender-qa,options={"status":"running","username":"mender-test-bot"}',
+        "info:auditlogs version master is being used in master",
+        "info:create-artifact-worker version master is being used in master",
+        "info:deployments version master is being used in master",
+        "info:deployments-enterprise version master is being used in master",
+        "info:deviceauth version master is being used in master",
+        "info:deviceconfig version master is being used in master",
+        "info:deviceconnect version master is being used in master",
+        "info:gui version master is being used in master",
+        "info:inventory version master is being used in master",
+        "info:inventory-enterprise version master is being used in master",
+        "info:mender version master is being used in master",
+        "info:mender-artifact version master is being used in master",
+        "info:mender-cli version master is being used in master",
+        "info:mender-connect version master is being used in master",
+        "info:mtls-ambassador version master is being used in master",
+        "info:tenantadm version master is being used in master",
+        "info:useradm version master is being used in master",
+        "info:useradm-enterprise version master is being used in master",
+        "info:workflows-enterprise version master is being used in master",
+        "gitlab.ListProjectPipelines: "
+        'path=Northern.tech/Mender/mender-qa,options={"status":"pending","username":"mender-test-bot"}',
+        "gitlab.ListProjectPipelines: "
+        'path=Northern.tech/Mender/mender-qa,options={"status":"running","username":"mender-test-bot"}',
         "gitlab.GetPipelineVariables: path=Northern.tech/Mender/mender-qa,id=1",
         "gitlab.GetPipelineVariables: path=Northern.tech/Mender/mender-qa,id=1",
-        "info:syncIfOSHasEnterpriseRepo: Merge to (master) in an OS repository detected. Syncing the repositories...",
+        "info:syncIfOSHasEnterpriseRepo: Merge to (master) in an OS repository "
+        "detected. Syncing the repositories...",
         "git.Run: /usr/bin/git init .",
-        "git.Run: /usr/bin/git remote add opensource git@github.com:/mendersoftware/workflows.git",
-        "git.Run: /usr/bin/git remote add enterprise git@github.com:/mendersoftware/workflows-enterprise.git",
-        "git.Run: /usr/bin/git remote add mender-test-bot git@github.com:/mender-test-bot/workflows-enterprise.git",
+        "git.Run: /usr/bin/git remote add opensource "
+        "git@github.com:/mendersoftware/workflows.git",
+        "git.Run: /usr/bin/git remote add enterprise "
+        "git@github.com:/mendersoftware/workflows-enterprise.git",
+        "git.Run: /usr/bin/git remote add mender-test-bot "
+        "git@github.com:/mender-test-bot/workflows-enterprise.git",
         "git.Run: /usr/bin/git config --add user.name mender-test-bot",
         "git.Run: /usr/bin/git config --add user.email mender@northern.tech",
         "git.Run: /usr/bin/git fetch opensource master",
         "git.Run: /usr/bin/git fetch enterprise master:mergeostoent_140",
         "git.Run: /usr/bin/git checkout mergeostoent_140",
-        "debug:Trying to Merge OS base branch: (master) including PR: (140) into Enterprise: (master)",
-        "git.Run: /usr/bin/git merge -m Merge OS base branch: (master) including PR: (140) into Enterprise: (master) opensource/master",
+        "debug:Trying to Merge OS base branch: (master) including PR: (140) into "
+        "Enterprise: (master)",
+        "git.Run: /usr/bin/git merge -m Merge OS base branch: (master) including PR: "
+        "(140) into Enterprise: (master) opensource/master",
         "git.Run: /usr/bin/git push --set-upstream mender-test-bot mergeostoent_140",
-        "info:Merged branch: opensource/workflows/master into enterprise/workflows/master in the Enterprise repo",
-        'github.CreatePullRequest: org=mendersoftware,repo=workflows-enterprise,pr={"title":"[Bot] Improve logging","head":"mender-test-bot:mergeostoent_140","base":"master","body":"Original PR: https://github.com/mendersoftware/workflows/pull/140\\n\\nChangelog: none\\r\\n\\r\\nSigned-off-by: Fabio Tranchitella \\u003cfabio.tranchitella@northern.tech\\u003e","maintainer_can_modify":true}',
+        "info:Merged branch: opensource/workflows/master into "
+        "enterprise/workflows/master in the Enterprise repo",
+        "github.CreatePullRequest: "
+        'org=mendersoftware,repo=workflows-enterprise,pr={"title":"[Bot] Improve '
+        'logging","head":"mender-test-bot:mergeostoent_140","base":"master","body":"Original '
+        "PR: https://github.com/mendersoftware/workflows/pull/140\\n\\nChangelog: "
+        "none\\r\\n\\r\\nSigned-off-by: Fabio Tranchitella "
+        '\\u003cfabio.tranchitella@northern.tech\\u003e","maintainer_can_modify":true}',
         "info:syncIfOSHasEnterpriseRepo: Created PR: 0 on Enterprise/workflows/master",
-        "debug:syncIfOSHasEnterpriseRepo: Created PR: id=666510619,number=140,title=Improve logging",
+        "debug:syncIfOSHasEnterpriseRepo: Created PR: "
+        "id=666510619,number=140,title=Improve logging",
         "debug:Trying to @mention the user in the newly created PR",
         "debug:userName: tranchitella",
-        'github.CreateComment: org=mendersoftware,repo=workflows-enterprise,number=0,comment={"body":"@tranchitella I have created a PR for you, ready to merge as soon as tests are passed"}',
+        "github.CreateComment: "
+        'org=mendersoftware,repo=workflows-enterprise,number=0,comment={"body":"@tranchitella '
+        'I have created a PR for you, ready to merge as soon as tests are passed"}',
         "info:Pull request event with action: closed",
         "info:workflows:140 would trigger 0 builds",
     ]
@@ -196,6 +215,7 @@ def test_push(integration_test_runner_url):
         "info:Pushed ref to GitLab: workflows-enterprise:refs/heads/master",
     ]
 
+
 def test_push_mender_qa_repo(integration_test_runner_url):
     res = requests.post(
         integration_test_runner_url + "/",
@@ -221,6 +241,7 @@ def test_push_mender_qa_repo(integration_test_runner_url):
         "info:Pushed ref to GitLab: mender-qa:refs/heads/master",
     ]
 
+
 def test_issue_comment(integration_test_runner_url):
     res = requests.post(
         integration_test_runner_url + "/",
@@ -239,44 +260,79 @@ def test_issue_comment(integration_test_runner_url):
         "github.IsOrganizationMember: org=mendersoftware,user=alfrunes",
         "info:Pull request event with action: opened",
         "git.Run: /usr/bin/git pull --rebase origin",
-        "info:deviceconnect/master is being used in the following integration: [master]",
-        "info:the following integration branches: [master] are using deviceconnect/master",
+        "info:deviceconnect/master is being used in the following integration: "
+        "[master]",
+        "info:the following integration branches: [master] are using "
+        "deviceconnect/master",
         "info:deviceconnect:109 will trigger 1 builds",
         "info:1: (main.buildOptions) {\n"
         ' pr: (string) (len=3) "109",\n'
         ' repo: (string) (len=13) "deviceconnect",\n'
         ' baseBranch: (string) (len=6) "master",\n'
-        ' commitSHA: (string) (len=40) "5503d260b6b72d4dd04543790522167073acf192",\n'
-        " makeQEMU: (bool) false\n}\n\n",
-        "info:auditlogs version origin/master is being used in master",
-        "info:create-artifact-worker version origin/master is being used in master",
-        "info:deployments version origin/master is being used in master",
-        "info:deployments-enterprise version origin/master is being used in master",
-        "info:deviceauth version origin/master is being used in master",
-        "info:deviceconfig version origin/master is being used in master",
-        "info:gui version origin/master is being used in master",
-        "info:inventory version origin/master is being used in master",
-        "info:inventory-enterprise version origin/master is being used in master",
-        "info:mender version origin/master is being used in master",
-        "info:mender-artifact version origin/master is being used in master",
-        "info:mender-cli version origin/master is being used in master",
-        "info:mender-connect version origin/master is being used in master",
-        "info:mtls-ambassador version origin/master is being used in master",
-        "info:tenantadm version origin/master is being used in master",
-        "info:useradm version origin/master is being used in master",
-        "info:useradm-enterprise version origin/master is being used in master",
-        "info:workflows version origin/master is being used in master",
-        "info:workflows-enterprise version origin/master is being used in master",
-        'gitlab.ListProjectPipelines: path=Northern.tech/Mender/mender-qa,options={"status":"pending","username":"mender-test-bot"}',
-        'gitlab.ListProjectPipelines: path=Northern.tech/Mender/mender-qa,options={"status":"running","username":"mender-test-bot"}',
+        ' commitSHA: (string) (len=40) "ddc66080a35f0d1d4bc1d3ef589a8226b2c9a02b",\n'
+        " makeQEMU: (bool) false\n"
+        "}\n"
+        "\n",
+        "info:auditlogs version master is being used in master",
+        "info:create-artifact-worker version master is being used in master",
+        "info:deployments version master is being used in master",
+        "info:deployments-enterprise version master is being used in master",
+        "info:deviceauth version master is being used in master",
+        "info:deviceconfig version master is being used in master",
+        "info:gui version master is being used in master",
+        "info:inventory version master is being used in master",
+        "info:inventory-enterprise version master is being used in master",
+        "info:mender version master is being used in master",
+        "info:mender-artifact version master is being used in master",
+        "info:mender-cli version master is being used in master",
+        "info:mender-connect version master is being used in master",
+        "info:mtls-ambassador version master is being used in master",
+        "info:tenantadm version master is being used in master",
+        "info:useradm version master is being used in master",
+        "info:useradm-enterprise version master is being used in master",
+        "info:workflows version master is being used in master",
+        "info:workflows-enterprise version master is being used in master",
+        "gitlab.ListProjectPipelines: "
+        'path=Northern.tech/Mender/mender-qa,options={"status":"pending","username":"mender-test-bot"}',
+        "gitlab.ListProjectPipelines: "
+        'path=Northern.tech/Mender/mender-qa,options={"status":"running","username":"mender-test-bot"}',
         "gitlab.GetPipelineVariables: path=Northern.tech/Mender/mender-qa,id=1",
         "gitlab.GetPipelineVariables: path=Northern.tech/Mender/mender-qa,id=1",
-        "info:Creating pipeline in project Northern.tech/Mender/mender-qa:master with variables: AUDITLOGS_REV:origin/master, BUILD_BEAGLEBONEBLACK:, BUILD_CLIENT:false, BUILD_QEMUX86_64_BIOS_GRUB:, BUILD_QEMUX86_64_BIOS_GRUB_GPT:, BUILD_QEMUX86_64_UEFI_GRUB:, BUILD_VEXPRESS_QEMU:, BUILD_VEXPRESS_QEMU_FLASH:, BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB:, CREATE_ARTIFACT_WORKER_REV:origin/master, DEPLOYMENTS_ENTERPRISE_REV:origin/master, DEPLOYMENTS_REV:origin/master, DEVICEAUTH_REV:origin/master, DEVICECONFIG_REV:origin/master, DEVICECONNECT_REV:pull/109/head, GUI_REV:origin/master, INTEGRATION_REV:master, INVENTORY_ENTERPRISE_REV:origin/master, INVENTORY_REV:origin/master, MENDER_ARTIFACT_REV:origin/master, MENDER_CLI_REV:origin/master, MENDER_CONNECT_REV:origin/master, MENDER_REV:origin/master, MTLS_AMBASSADOR_REV:origin/master, RUN_INTEGRATION_TESTS:true, TENANTADM_REV:origin/master, TEST_QEMUX86_64_BIOS_GRUB:, TEST_QEMUX86_64_BIOS_GRUB_GPT:, TEST_QEMUX86_64_UEFI_GRUB:, TEST_VEXPRESS_QEMU:, TEST_VEXPRESS_QEMU_FLASH:, TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB:, USERADM_ENTERPRISE_REV:origin/master, USERADM_REV:origin/master, WORKFLOWS_ENTERPRISE_REV:origin/master, WORKFLOWS_REV:origin/master, ",
+        "info:Creating pipeline in project Northern.tech/Mender/mender-qa:master with "
+        "variables: AUDITLOGS_REV:master, BUILD_BEAGLEBONEBLACK:, BUILD_CLIENT:false, "
+        "BUILD_QEMUX86_64_BIOS_GRUB:, BUILD_QEMUX86_64_BIOS_GRUB_GPT:, "
+        "BUILD_QEMUX86_64_UEFI_GRUB:, BUILD_VEXPRESS_QEMU:, "
+        "BUILD_VEXPRESS_QEMU_FLASH:, BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB:, "
+        "CREATE_ARTIFACT_WORKER_REV:master, DEPLOYMENTS_ENTERPRISE_REV:master, "
+        "DEPLOYMENTS_REV:master, DEVICEAUTH_REV:master, DEVICECONFIG_REV:master, "
+        "DEVICECONNECT_REV:pull/109/head, GUI_REV:master, INTEGRATION_REV:master, "
+        "INVENTORY_ENTERPRISE_REV:master, INVENTORY_REV:master, "
+        "MENDER_ARTIFACT_REV:master, MENDER_CLI_REV:master, "
+        "MENDER_CONNECT_REV:master, MENDER_REV:master, MTLS_AMBASSADOR_REV:master, "
+        "RUN_INTEGRATION_TESTS:true, TENANTADM_REV:master, "
+        "TEST_QEMUX86_64_BIOS_GRUB:, TEST_QEMUX86_64_BIOS_GRUB_GPT:, "
+        "TEST_QEMUX86_64_UEFI_GRUB:, TEST_VEXPRESS_QEMU:, TEST_VEXPRESS_QEMU_FLASH:, "
+        "TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB:, USERADM_ENTERPRISE_REV:master, "
+        "USERADM_REV:master, WORKFLOWS_ENTERPRISE_REV:master, WORKFLOWS_REV:master, ",
         "gitlab.CreatePipeline: "
-        'path=Northern.tech/Mender/mender-qa,options={"ref":"master","variables":[{"key":"AUDITLOGS_REV","value":"origin/master"},{"key":"BUILD_BEAGLEBONEBLACK","value":""},{"key":"BUILD_CLIENT","value":"false"},{"key":"BUILD_QEMUX86_64_BIOS_GRUB","value":""},{"key":"BUILD_QEMUX86_64_BIOS_GRUB_GPT","value":""},{"key":"BUILD_QEMUX86_64_UEFI_GRUB","value":""},{"key":"BUILD_VEXPRESS_QEMU","value":""},{"key":"BUILD_VEXPRESS_QEMU_FLASH","value":""},{"key":"BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":""},{"key":"CREATE_ARTIFACT_WORKER_REV","value":"origin/master"},{"key":"DEPLOYMENTS_ENTERPRISE_REV","value":"origin/master"},{"key":"DEPLOYMENTS_REV","value":"origin/master"},{"key":"DEVICEAUTH_REV","value":"origin/master"},{"key":"DEVICECONFIG_REV","value":"origin/master"},{"key":"DEVICECONNECT_REV","value":"pull/109/head"},{"key":"GUI_REV","value":"origin/master"},{"key":"INTEGRATION_REV","value":"master"},{"key":"INVENTORY_ENTERPRISE_REV","value":"origin/master"},{"key":"INVENTORY_REV","value":"origin/master"},{"key":"MENDER_ARTIFACT_REV","value":"origin/master"},{"key":"MENDER_CLI_REV","value":"origin/master"},{"key":"MENDER_CONNECT_REV","value":"origin/master"},{"key":"MENDER_REV","value":"origin/master"},{"key":"MTLS_AMBASSADOR_REV","value":"origin/master"},{"key":"RUN_INTEGRATION_TESTS","value":"true"},{"key":"TENANTADM_REV","value":"origin/master"},{"key":"TEST_QEMUX86_64_BIOS_GRUB","value":""},{"key":"TEST_QEMUX86_64_BIOS_GRUB_GPT","value":""},{"key":"TEST_QEMUX86_64_UEFI_GRUB","value":""},{"key":"TEST_VEXPRESS_QEMU","value":""},{"key":"TEST_VEXPRESS_QEMU_FLASH","value":""},{"key":"TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":""},{"key":"USERADM_ENTERPRISE_REV","value":"origin/master"},{"key":"USERADM_REV","value":"origin/master"},{"key":"WORKFLOWS_ENTERPRISE_REV","value":"origin/master"},{"key":"WORKFLOWS_REV","value":"origin/master"}]}',
+        'path=Northern.tech/Mender/mender-qa,options={"ref":"master","variables":[{"key":"AUDITLOGS_REV","value":"master"},{"key":"BUILD_BEAGLEBONEBLACK","value":""},{"key":"BUILD_CLIENT","value":"false"},{"key":"BUILD_QEMUX86_64_BIOS_GRUB","value":""},{"key":"BUILD_QEMUX86_64_BIOS_GRUB_GPT","value":""},{"key":"BUILD_QEMUX86_64_UEFI_GRUB","value":""},{"key":"BUILD_VEXPRESS_QEMU","value":""},{"key":"BUILD_VEXPRESS_QEMU_FLASH","value":""},{"key":"BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":""},{"key":"CREATE_ARTIFACT_WORKER_REV","value":"master"},{"key":"DEPLOYMENTS_ENTERPRISE_REV","value":"master"},{"key":"DEPLOYMENTS_REV","value":"master"},{"key":"DEVICEAUTH_REV","value":"master"},{"key":"DEVICECONFIG_REV","value":"master"},{"key":"DEVICECONNECT_REV","value":"pull/109/head"},{"key":"GUI_REV","value":"master"},{"key":"INTEGRATION_REV","value":"master"},{"key":"INVENTORY_ENTERPRISE_REV","value":"master"},{"key":"INVENTORY_REV","value":"master"},{"key":"MENDER_ARTIFACT_REV","value":"master"},{"key":"MENDER_CLI_REV","value":"master"},{"key":"MENDER_CONNECT_REV","value":"master"},{"key":"MENDER_REV","value":"master"},{"key":"MTLS_AMBASSADOR_REV","value":"master"},{"key":"RUN_INTEGRATION_TESTS","value":"true"},{"key":"TENANTADM_REV","value":"master"},{"key":"TEST_QEMUX86_64_BIOS_GRUB","value":""},{"key":"TEST_QEMUX86_64_BIOS_GRUB_GPT","value":""},{"key":"TEST_QEMUX86_64_UEFI_GRUB","value":""},{"key":"TEST_VEXPRESS_QEMU","value":""},{"key":"TEST_VEXPRESS_QEMU_FLASH","value":""},{"key":"TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":""},{"key":"USERADM_ENTERPRISE_REV","value":"master"},{"key":"USERADM_REV","value":"master"},{"key":"WORKFLOWS_ENTERPRISE_REV","value":"master"},{"key":"WORKFLOWS_REV","value":"master"}]}',
         "info:Created pipeline: ",
         "github.CreateComment: "
         'org=mendersoftware,repo=deviceconnect,number=109,comment={"body":"\\nHello '
-        ":smile_cat: I created a pipeline for you here: [Pipeline-0]()\\n\\n\\u003cdetails\\u003e\\n    \\u003csummary\\u003eBuild Configuration Matrix\\u003c/summary\\u003e\\u003cp\\u003e\\n\\n| Key   | Value |\\n| ----- | ----- |\\n| AUDITLOGS_REV | origin/master |\\n| BUILD_CLIENT | false |\\n| CREATE_ARTIFACT_WORKER_REV | origin/master |\\n| DEPLOYMENTS_ENTERPRISE_REV | origin/master |\\n| DEPLOYMENTS_REV | origin/master |\\n| DEVICEAUTH_REV | origin/master |\\n| DEVICECONFIG_REV | origin/master |\\n| DEVICECONNECT_REV | pull/109/head |\\n| GUI_REV | origin/master |\\n| INTEGRATION_REV | master |\\n| INVENTORY_ENTERPRISE_REV | origin/master |\\n| INVENTORY_REV | origin/master |\\n| MENDER_ARTIFACT_REV | origin/master |\\n| MENDER_CLI_REV | origin/master |\\n| MENDER_CONNECT_REV | origin/master |\\n| MENDER_REV | origin/master |\\n| MTLS_AMBASSADOR_REV | origin/master |\\n| RUN_INTEGRATION_TESTS | true |\\n| TENANTADM_REV | origin/master |\\n| USERADM_ENTERPRISE_REV | origin/master |\\n| USERADM_REV | origin/master |\\n| WORKFLOWS_ENTERPRISE_REV | origin/master |\\n| WORKFLOWS_REV | origin/master "
-        '|\\n\\n\\n \\u003c/p\\u003e\\u003c/details\\u003e\\n"}',
+        ":smile_cat: I created a pipeline for you here: "
+        "[Pipeline-0]()\\n\\n\\u003cdetails\\u003e\\n    \\u003csummary\\u003eBuild "
+        "Configuration Matrix\\u003c/summary\\u003e\\u003cp\\u003e\\n\\n| Key   | "
+        "Value |\\n| ----- | ----- |\\n| AUDITLOGS_REV | master |\\n| BUILD_CLIENT | "
+        "false |\\n| CREATE_ARTIFACT_WORKER_REV | master |\\n| "
+        "DEPLOYMENTS_ENTERPRISE_REV | master |\\n| DEPLOYMENTS_REV | master |\\n| "
+        "DEVICEAUTH_REV | master |\\n| DEVICECONFIG_REV | master |\\n| "
+        "DEVICECONNECT_REV | pull/109/head |\\n| GUI_REV | master |\\n| "
+        "INTEGRATION_REV | master |\\n| INVENTORY_ENTERPRISE_REV | master |\\n| "
+        "INVENTORY_REV | master |\\n| MENDER_ARTIFACT_REV | master |\\n| "
+        "MENDER_CLI_REV | master |\\n| MENDER_CONNECT_REV | master |\\n| MENDER_REV | "
+        "master |\\n| MTLS_AMBASSADOR_REV | master |\\n| RUN_INTEGRATION_TESTS | true "
+        "|\\n| TENANTADM_REV | master |\\n| USERADM_ENTERPRISE_REV | master |\\n| "
+        "USERADM_REV | master |\\n| WORKFLOWS_ENTERPRISE_REV | master |\\n| "
+        "WORKFLOWS_REV | master |\\n\\n\\n "
+        '\\u003c/p\\u003e\\u003c/details\\u003e\\n"}',
     ]


### PR DESCRIPTION
Though it's probably not the safest way to strip the "ref directory", the same logic is used elsewhere...