### PR TITLE
Enable CD for cfengine-repos-sync deployment too

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -72,4 +72,4 @@ publish:acceptance:
 
 sync:image:
   variables:
-    TARGET_MANIFEST_FILE: "kubernetes/mender-test-runner/test-runner-deployment.yaml"
+    TARGET_MANIFEST_FILE: "kubernetes/mender-test-runner/test-runner-deployment.yaml,kubernetes/cfengine-repos-sync/repos-sync-cfengine-com-deployment.yaml"

--- a/README.md
+++ b/README.md
@@ -11,9 +11,7 @@ This is a Mender specific feature.
 
 ### GitHub -> GitLab sync
 
-Set `WATCH_REPOS_SYNC` for the list of repositories for which to do
-GitHub->Gitlab git branches sync. Default is a list of the Mender Enterprise
-repositories.
+All repositories from the configured GitHub organization are synced with GitLab.
 
 ### GitLab PR branches
 


### PR DESCRIPTION
Which uses the same image as mender-test-runner.

Bonus:
* README: Update GitHub->GitLab sync information
It is not configurable since 1b4bc61.