### PR TITLE
Extract GitHub Organization from webhooks payload

### DIFF
--- a/cherrypicks.go
+++ b/cherrypicks.go
@@ -48,7 +48,7 @@ func suggestCherryPicks(log *logrus.Entry, pr *github.PullRequestEvent, githubCl
 
 	// initialize the git work area
 	repo := pr.GetRepo().GetName()
-	repoURL := getRemoteURLGitHub(conf.githubProtocol, githubOrganization, repo)
+	repoURL := getRemoteURLGitHub(conf.githubProtocol, conf.githubOrganization, repo)
 	prNumber := strconv.Itoa(pr.GetNumber())
 	prBranchName := "pr_" + prNumber
 	state, err := git.Commands(
@@ -128,7 +128,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 	comment := github.IssueComment{
 		Body: &commentBody,
 	}
-	if err := githubClient.CreateComment(context.Background(), githubOrganization,
+	if err := githubClient.CreateComment(context.Background(), conf.githubOrganization,
 		pr.GetRepo().GetName(), pr.GetNumber(), &comment); err != nil {
 		log.Infof("Failed to comment on the pr: %v, Error: %s", pr, err.Error())
 		return err

--- a/cherrypicks_test.go
+++ b/cherrypicks_test.go
@@ -16,6 +16,9 @@ import (
 )
 
 func TestSuggestCherryPicks(t *testing.T) {
+
+	gitHubOrg := "mendersoftware"
+
 	testCases := map[string]struct {
 		pr      *github.PullRequestEvent
 		err     error
@@ -164,7 +167,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 					mock.MatchedBy(func(ctx context.Context) bool {
 						return true
 					}),
-					githubOrganization,
+					gitHubOrg,
 					*tc.pr.Repo.Name,
 					*tc.pr.Number,
 					tc.comment,
@@ -172,7 +175,8 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			}
 
 			conf := &config{
-				githubProtocol: gitProtocolHTTP,
+				githubProtocol:     gitProtocolHTTP,
+				githubOrganization: gitHubOrg,
 			}
 			conf.integrationDirectory = tmpdir
 

--- a/entfork_sync.go
+++ b/entfork_sync.go
@@ -131,9 +131,9 @@ func createPRBranchOnEnterprise(log *logrus.Entry, repo, branchName, PRNumber, P
 	state, err := git.Commands(
 		git.Command("init", "."),
 		git.Command("remote", "add", "opensource",
-			getRemoteURLGitHub(conf.githubProtocol, githubOrganization, repo)),
+			getRemoteURLGitHub(conf.githubProtocol, conf.githubOrganization, repo)),
 		git.Command("remote", "add", "enterprise",
-			getRemoteURLGitHub(conf.githubProtocol, githubOrganization, repo+"-enterprise")),
+			getRemoteURLGitHub(conf.githubProtocol, conf.githubOrganization, repo+"-enterprise")),
 		git.Command("remote", "add", githubBotName,
 			getRemoteURLGitHub(conf.githubProtocol, githubBotName, repo+"-enterprise")),
 		git.Command("config", "--add", "user.name", githubBotName),
@@ -219,7 +219,7 @@ func createPullRequestFromTestBotFork(args createPRArgs) (*github.PullRequest, e
 	}
 
 	client := clientgithub.NewGitHubClient(args.conf.githubToken, args.conf.dryRunMode)
-	pr, err := client.CreatePullRequest(context.Background(), githubOrganization, args.repo, newPR)
+	pr, err := client.CreatePullRequest(context.Background(), args.conf.githubOrganization, args.repo, newPR)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to create the PR for: (%s) %v", args.repo, err)
 	}
@@ -304,5 +304,5 @@ This can be done by following:
 	}
 
 	client := clientgithub.NewGitHubClient(args.conf.githubToken, args.conf.dryRunMode)
-	return client.CreateComment(context.Background(), githubOrganization, args.repo, args.pr.GetNumber(), &comment)
+	return client.CreateComment(context.Background(), args.conf.githubOrganization, args.repo, args.pr.GetNumber(), &comment)
 }

--- a/gitlab_sync.go
+++ b/gitlab_sync.go
@@ -18,7 +18,7 @@ func syncRemoteRef(log *logrus.Entry, org, repo, ref string, conf *config) error
 	state, err := git.Commands(
 		git.Command("init", "."),
 		git.Command("remote", "add", "github",
-			getRemoteURLGitHub(conf.githubProtocol, githubOrganization, repo)),
+			getRemoteURLGitHub(conf.githubProtocol, conf.githubOrganization, repo)),
 		git.Command("remote", "add", "gitlab", remoteURLGitLab),
 	)
 	defer state.Cleanup()

--- a/main.go
+++ b/main.go
@@ -28,6 +28,7 @@ type config struct {
 	dryRunMode                       bool
 	githubSecret                     []byte
 	githubProtocol                   gitProtocol
+	githubOrganization               string
 	githubToken                      string
 	gitlabToken                      string
 	gitlabBaseURL                    string
@@ -106,8 +107,7 @@ const (
 )
 
 const (
-	githubOrganization = "mendersoftware"
-	githubBotName      = "mender-test-bot"
+	githubBotName = "mender-test-bot"
 )
 
 const (
@@ -183,6 +183,12 @@ func processGitHubWebhookRequest(ctx *gin.Context, payload []byte, githubClient 
 }
 
 func processGitHubWebhook(ctx *gin.Context, webhookType string, webhookEvent interface{}, githubClient clientgithub.Client, conf *config) error {
+	githubOrganization, err := getGitHubOrganization(webhookType, webhookEvent)
+	if err != nil {
+		logrus.Warnln("ignoring event: ", err.Error())
+		return nil
+	}
+	conf.githubOrganization = githubOrganization
 	switch webhookType {
 	case "pull_request":
 		pr := webhookEvent.(*github.PullRequestEvent)

--- a/main_comment.go
+++ b/main_comment.go
@@ -22,7 +22,7 @@ func processGitHubComment(ctx *gin.Context, comment *github.IssueCommentEvent, g
 	}
 
 	// accept commands only from organization members
-	if !githubClient.IsOrganizationMember(ctx, githubOrganization, comment.Sender.GetLogin()) {
+	if !githubClient.IsOrganizationMember(ctx, conf.githubOrganization, comment.Sender.GetLogin()) {
 		log.Warnf("%s commented, but he/she is not a member of our organization, ignoring", comment.Sender.GetLogin())
 		return nil
 	}
@@ -54,7 +54,7 @@ func processGitHubComment(ctx *gin.Context, comment *github.IssueCommentEvent, g
 		return err
 	}
 
-	pr, err := githubClient.GetPullRequest(ctx, githubOrganization, comment.GetRepo().GetName(), prNumber)
+	pr, err := githubClient.GetPullRequest(ctx, conf.githubOrganization, comment.GetRepo().GetName(), prNumber)
 	if err != nil {
 		log.Errorf("Unable to retrieve the pull request: %s", err.Error())
 		return err

--- a/main_comment_test.go
+++ b/main_comment_test.go
@@ -14,6 +14,9 @@ import (
 )
 
 func TestProcessGitHubWebhook(t *testing.T) {
+
+	gitHubOrg := "mendersoftware"
+
 	testCases := map[string]struct {
 		webhookType  string
 		webhookEvent interface{}
@@ -31,6 +34,11 @@ func TestProcessGitHubWebhook(t *testing.T) {
 			webhookType: "issue_comment",
 			webhookEvent: &github.IssueCommentEvent{
 				Action: github.String("updated"),
+				Repo: &github.Repository{
+					Owner: &github.User{
+						Login: github.String(gitHubOrg),
+					},
+				},
 			},
 		},
 		"comment from non-mendersoftware user, ignore": {
@@ -39,6 +47,11 @@ func TestProcessGitHubWebhook(t *testing.T) {
 				Action: github.String("created"),
 				Sender: &github.User{
 					Login: github.String("not-member"),
+				},
+				Repo: &github.Repository{
+					Owner: &github.User{
+						Login: github.String(gitHubOrg),
+					},
 				},
 			},
 
@@ -54,6 +67,11 @@ func TestProcessGitHubWebhook(t *testing.T) {
 				Sender: &github.User{
 					Login: github.String("not-member"),
 				},
+				Repo: &github.Repository{
+					Owner: &github.User{
+						Login: github.String(gitHubOrg),
+					},
+				},
 			},
 
 			isOrganizationMember: github.Bool(false),
@@ -68,6 +86,11 @@ func TestProcessGitHubWebhook(t *testing.T) {
 				Sender: &github.User{
 					Login: github.String("not-member"),
 				},
+				Repo: &github.Repository{
+					Owner: &github.User{
+						Login: github.String(gitHubOrg),
+					},
+				},
 			},
 
 			isOrganizationMember: github.Bool(false),
@@ -81,6 +104,11 @@ func TestProcessGitHubWebhook(t *testing.T) {
 				},
 				Sender: &github.User{
 					Login: github.String("member"),
+				},
+				Repo: &github.Repository{
+					Owner: &github.User{
+						Login: github.String(gitHubOrg),
+					},
 				},
 			},
 
@@ -100,6 +128,11 @@ func TestProcessGitHubWebhook(t *testing.T) {
 				},
 				Sender: &github.User{
 					Login: github.String("member"),
+				},
+				Repo: &github.Repository{
+					Owner: &github.User{
+						Login: github.String(gitHubOrg),
+					},
 				},
 			},
 
@@ -121,6 +154,9 @@ func TestProcessGitHubWebhook(t *testing.T) {
 				},
 				Repo: &github.Repository{
 					Name: github.String("integration-test-runner"),
+					Owner: &github.User{
+						Login: github.String(gitHubOrg),
+					},
 				},
 				Sender: &github.User{
 					Login: github.String("member"),
@@ -149,6 +185,9 @@ func TestProcessGitHubWebhook(t *testing.T) {
 				},
 				Repo: &github.Repository{
 					Name: github.String("integration-test-runner"),
+					Owner: &github.User{
+						Login: github.String(gitHubOrg),
+					},
 				},
 				Sender: &github.User{
 					Login: github.String("member"),
@@ -178,7 +217,7 @@ func TestProcessGitHubWebhook(t *testing.T) {
 					mock.MatchedBy(func(ctx context.Context) bool {
 						return true
 					}),
-					githubOrganization,
+					gitHubOrg,
 					tc.webhookEvent.(*github.IssueCommentEvent).GetSender().GetLogin(),
 				).Return(*tc.isOrganizationMember)
 			}
@@ -188,14 +227,15 @@ func TestProcessGitHubWebhook(t *testing.T) {
 					mock.MatchedBy(func(ctx context.Context) bool {
 						return true
 					}),
-					githubOrganization,
+					gitHubOrg,
 					tc.repo,
 					tc.prNumber,
 				).Return(tc.pullRequest, tc.pullRequestErr)
 			}
 
 			conf := &config{
-				githubProtocol: gitProtocolHTTP,
+				githubProtocol:     gitProtocolHTTP,
+				githubOrganization: gitHubOrg,
 			}
 
 			ctx := &gin.Context{}

--- a/main_pullrequest_test.go
+++ b/main_pullrequest_test.go
@@ -19,6 +19,9 @@ func TestBotHasAlreadyCommentedOnPR(t *testing.T) {
 		error         error
 	}
 	commentString := github.String(", Let me know if you want to start the integration pipeline by mentioning me and the command \"")
+	conf := &config{
+		githubOrganization: "mendersoftware",
+	}
 	testCases := map[string]struct {
 		pr             *github.PullRequestEvent
 		expectedResult bool
@@ -86,7 +89,7 @@ func TestBotHasAlreadyCommentedOnPR(t *testing.T) {
 			).Return(tc.returnVals.issueComments, tc.returnVals.error)
 
 			log := logrus.NewEntry(logrus.StandardLogger())
-			assert.Equal(t, tc.expectedResult, botHasAlreadyCommentedOnPR(log, mclient, tc.pr, *commentString))
+			assert.Equal(t, tc.expectedResult, botHasAlreadyCommentedOnPR(log, mclient, tc.pr, *commentString, conf))
 		})
 	}
 }

--- a/menderqa_pipeline.go
+++ b/menderqa_pipeline.go
@@ -173,7 +173,7 @@ Hello :smile_cat: I created a pipeline for you here: [Pipeline-{{.Pipeline.ID}}]
 
 	client := clientgithub.NewGitHubClient(conf.githubToken, conf.dryRunMode)
 	err = client.CreateComment(context.Background(),
-		githubOrganization, pr.GetRepo().GetName(), pr.GetNumber(), &comment)
+		conf.githubOrganization, pr.GetRepo().GetName(), pr.GetNumber(), &comment)
 	if err != nil {
 		log.Infof("Failed to comment on the pr: %v, Error: %s", pr, err.Error())
 	}

--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -91,7 +91,7 @@ func syncPullRequestBranch(log *logrus.Entry, pr *github.PullRequestEvent, conf 
 		return "", fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
-	repoURL := getRemoteURLGitHub(conf.githubProtocol, githubOrganization, repo)
+	repoURL := getRemoteURLGitHub(conf.githubProtocol, conf.githubOrganization, repo)
 	gitcmd = git.Command("remote", "add", "github", repoURL)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()

--- a/util.go
+++ b/util.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"fmt"
+
+	"github.com/google/go-github/v28/github"
 )
 
 type gitProtocol int
@@ -33,4 +35,20 @@ func getRemoteURLGitLab(org, repo string) (string, error) {
 		remoteURL = "git@gitlab.com:" + v
 	}
 	return remoteURL, nil
+}
+
+func getGitHubOrganization(webhookType string, webhookEvent interface{}) (string, error) {
+	switch webhookType {
+	case "pull_request":
+		pr := webhookEvent.(*github.PullRequestEvent)
+		return pr.GetOrganization().GetLogin(), nil
+	case "push":
+		push := webhookEvent.(*github.PushEvent)
+		return push.GetRepo().GetOrganization(), nil
+	case "issue_comment":
+		comment := webhookEvent.(*github.IssueCommentEvent)
+		return comment.GetRepo().GetOwner().GetLogin(), nil
+	}
+	return "", fmt.Errorf("getGitHubOrganization cannot get organizatoin from webhook type %q", webhookType)
+
 }


### PR DESCRIPTION
Instead of hard-coding it to `mendersoftware`, so that it can be used by
other GitHub Organizations (namely: CFEngine).