### PR TITLE
Freeze the integration repository used in tests

### DIFF
--- a/cherrypicks_test.go
+++ b/cherrypicks_test.go
@@ -181,7 +181,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 	}
 	defer os.RemoveAll(tmpdir)
 
-	gitSetup := exec.Command("git", "clone", "https://github.com/mendersoftware/integration.git", tmpdir)
+	gitSetup := exec.Command("git", "clone", "https://github.com/mender-test-bot/integration.git", tmpdir)
 	gitSetup.Dir = tmpdir
 	_, err = gitSetup.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
In order to always have a stable pipe, freeze the integration repository used,
through referring to the bot's own and unused fork of the repository.

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>