### PR TITLE
menderqa_pipeline: Base the watch repositories list in release_tool list

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"sync"
 	"time"
 
@@ -26,15 +25,14 @@ import (
 var mutex = &sync.Mutex{}
 
 type config struct {
-	dryRunMode                       bool
-	githubSecret                     []byte
-	githubProtocol                   gitProtocol
-	githubOrganization               string
-	githubToken                      string
-	gitlabToken                      string
-	gitlabBaseURL                    string
-	integrationDirectory             string
-	watchRepositoriesTriggerPipeline []string // List of repositories for which to trigger mender-qa pipeline
+	dryRunMode           bool
+	githubSecret         []byte
+	githubProtocol       gitProtocol
+	githubOrganization   string
+	githubToken          string
+	gitlabToken          string
+	gitlabBaseURL        string
+	integrationDirectory string
 }
 
 type buildOptions struct {
@@ -45,41 +43,9 @@ type buildOptions struct {
 	makeQEMU   bool
 }
 
-// List of repos for which the integration pipeline shall be run
-// It can be overridden with env. variable WATCH_REPOS_PIPELINE
-// Keep in sync with release_tool.py --list git --all
-var defaultWatchRepositoriesPipeline = []string{
-	"auditlogs",
-	"azure-iot-manager",
-	"mender-auth-azure-iot",
-	"create-artifact-worker",
-	"deployments",
-	"deployments-enterprise",
-	"deviceadm",
-	"deviceauth",
-	"deviceauth-enterprise",
-	"deviceconfig",
-	"deviceconnect",
-	"devicemonitor",
-	//"gui",
-	"integration",
-	"inventory",
-	"inventory-enterprise",
-	"mender",
-	"mender-api-gateway-docker",
-	"mender-artifact",
-	"mender-cli",
-	"mender-conductor",
-	"mender-conductor-enterprise",
-	"mender-connect",
-	"monitor-client",
-	"mtls-ambassador",
-	"tenantadm",
-	"useradm",
-	"useradm-enterprise",
-	"workflows",
-	"workflows-enterprise",
-	// repos outside of release_tool.py
+// List of repos besides the ones in release_tool.py for
+// which the integration pipeline shall be run
+var extraWatchRepositoriesPipeline = []string{
 	"meta-mender",
 }
 
@@ -121,7 +87,6 @@ const (
 )
 
 func getConfig() (*config, error) {
-	var repositoryWatchListPipeline []string
 	dryRunMode := os.Getenv("DRY_RUN") != ""
 	githubSecret := os.Getenv("GITHUB_SECRET")
 	githubToken := os.Getenv("GITHUB_TOKEN")
@@ -142,13 +107,6 @@ func getConfig() (*config, error) {
 		}
 	}
 
-	watchRepositoriesTriggerPipeline, ok := os.LookupEnv("WATCH_REPOS_PIPELINE")
-	if ok {
-		repositoryWatchListPipeline = strings.Split(watchRepositoriesTriggerPipeline, ",")
-	} else {
-		repositoryWatchListPipeline = defaultWatchRepositoriesPipeline
-	}
-
 	switch {
 	case githubSecret == "" && !dryRunMode:
 		return &config{}, fmt.Errorf("set GITHUB_SECRET")
@@ -163,14 +121,13 @@ func getConfig() (*config, error) {
 	}
 
 	return &config{
-		dryRunMode:                       dryRunMode,
-		githubSecret:                     []byte(githubSecret),
-		githubProtocol:                   gitProtocolSSH,
-		githubToken:                      githubToken,
-		gitlabToken:                      gitlabToken,
-		gitlabBaseURL:                    gitlabBaseURL,
-		integrationDirectory:             integrationDirectory,
-		watchRepositoriesTriggerPipeline: repositoryWatchListPipeline,
+		dryRunMode:           dryRunMode,
+		githubSecret:         []byte(githubSecret),
+		githubProtocol:       gitProtocolSSH,
+		githubToken:          githubToken,
+		gitlabToken:          gitlabToken,
+		gitlabBaseURL:        gitlabBaseURL,
+		integrationDirectory: integrationDirectory,
 	}, nil
 }
 

--- a/menderqa_pipeline.go
+++ b/menderqa_pipeline.go
@@ -45,7 +45,17 @@ func getBuilds(log *logrus.Entry, conf *config, pr *github.PullRequestEvent) []b
 
 	makeQEMU := false
 
-	for _, watchRepo := range conf.watchRepositoriesTriggerPipeline {
+	// we need to have the latest integration/master branch in order to use the release_tool.py
+	if err := updateIntegrationRepo(conf); err != nil {
+		log.Warnf(err.Error())
+	}
+
+	watchRepositoriesTriggerPipeline, err := getListOfWatchedRepositories(conf)
+	if err != nil {
+		log.Warnf(err.Error())
+	}
+
+	for _, watchRepo := range watchRepositoriesTriggerPipeline {
 		// make sure the repo that the pull request is performed against is
 		// one that we are watching.
 
@@ -56,11 +66,6 @@ func getBuilds(log *logrus.Entry, conf *config, pr *github.PullRequestEvent) []b
 				if repo == qemuRepo {
 					makeQEMU = true
 				}
-			}
-
-			// we need to have the latest integration/master branch in order to use the release_tool.py
-			if err := updateIntegrationRepo(conf); err != nil {
-				log.Warnf(err.Error())
 			}
 
 			switch repo {

--- a/menderqa_pipeline_helpers.go
+++ b/menderqa_pipeline_helpers.go
@@ -100,3 +100,24 @@ func getListOfVersionedRepositories(inVersion string, conf *config) ([]string, e
 
 	return strings.Split(strings.TrimSpace(string(output)), "\n"), nil
 }
+
+func getListOfAllRepositories(conf *config) ([]string, error) {
+	c := exec.Command("python3", "release_tool.py", "--list", "--all")
+	c.Dir = conf.integrationDirectory + "/extra/"
+	output, err := c.Output()
+	if err != nil {
+		return nil, fmt.Errorf("getListOfAllRepositories: Error: %v (%s)", err, output)
+	}
+
+	return strings.Split(strings.TrimSpace(string(output)), "\n"), nil
+}
+
+func getListOfWatchedRepositories(conf *config) ([]string, error) {
+
+	listOfAllRepositories, err := getListOfAllRepositories(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	return append(listOfAllRepositories, extraWatchRepositoriesPipeline...), nil
+}

--- a/tests/tests/golden-files/test_pull_request_opened_from_branch.yml
+++ b/tests/tests/golden-files/test_pull_request_opened_from_branch.yml
@@ -7,4 +7,5 @@ output:
 - 'debug:syncIfOSHasEnterpriseRepo: Repository without Enterprise fork detected: (mender-docs).
   Not syncing'
 - 'info:Pull request event with action: opened'
+- 'git.Run: /usr/bin/git pull --rebase origin'
 - info:mender-docs:1483 would trigger 0 builds


### PR DESCRIPTION
So that we remove one point of duplication in our ecosystem.

The list was only being used to trigger in which repos to offer the
"start pipeline" functionality. Instead of a full list, hard-code only
the repos that are not part of the tool (namely: meta-mender).

The only drawback is that we are now suggesting in `gui` to start the
pipeline, but this might come in handy in the future if we integrate the
e2e tests with mender-qa.