### PR TITLE
fix: cherry-picks to standard branches now supported

### DIFF
--- a/cherrypicks.go
+++ b/cherrypicks.go
@@ -332,7 +332,7 @@ I did my very best, and this is the result of the cherry pick operation:
 
 func parseCherryTargetBranches(body string) []string {
 	matches := []string{}
-	regex := regexp.MustCompile(` *\* *([0-9]+\.[0-9]+\.x)`)
+	regex := regexp.MustCompile(` *\* *(([[:word:]]+[_\.-]?)+)`)
 	for _, line := range strings.Split(body, "\n") {
 		if m := regex.FindStringSubmatch(line); len(m) > 1 {
 			matches = append(matches, m[1])

--- a/cherrypicks_test.go
+++ b/cherrypicks_test.go
@@ -228,7 +228,7 @@ func TestCherryTargetBranches(t *testing.T) {
 		input    string
 		expected []string
 	}{
-		"Success": {
+		"Success nice syntax": {
 			input: `
 cherry pick to:
     * 2.6.x
@@ -237,11 +237,11 @@ cherry pick to:
 `,
 			expected: []string{"2.6.x", "2.5.x", "2.4.x"},
 		},
-		"Failure": {
+		"Success messy syntax": {
 			input: `cherry pick to:
  * 2.4.1
 * 2.5.3`,
-			expected: []string{},
+			expected: []string{"2.4.1", "2.5.3"},
 		},
 	}
 
@@ -356,5 +356,49 @@ cherry-pick to:
 				assert.NoError(t, err)
 			}
 		})
+	}
+}
+
+func TestParseCherryTargetBranches(t *testing.T) {
+	tests := map[string]struct {
+		body     string
+		expected string
+	}{
+		"master": {
+			body: `cherry-pick to:
+		* master`,
+			expected: "master",
+		},
+		"hosted": {
+			body: `cherry-pick to:
+		* hosted`,
+			expected: "hosted",
+		},
+		"staging": {
+			body: `cherry-pick to:
+		* staging`,
+			expected: "staging",
+		},
+		"feature-branch": {
+			body: `cherry-pick to:
+		* feature-independe_testing-1`,
+			expected: "feature-independe_testing-1",
+		},
+		"1.2.x": {
+			body: `cherry-pick to:
+		* 1.2.x`,
+			expected: "1.2.x",
+		},
+		"1.2.x with escape char": {
+			body: `cherry-pick to:
+		* 1.2.x\r`,
+			expected: "1.2.x",
+		},
+	}
+
+	for name, test := range tests {
+		t.Log(name)
+		res := parseCherryTargetBranches(test.body)
+		assert.Equal(t, test.expected, res[0])
 	}
 }

--- a/cherrypicks_test.go
+++ b/cherrypicks_test.go
@@ -91,7 +91,7 @@ func TestSuggestCherryPicks(t *testing.T) {
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
-2.1.x (release 3.1.x)
+2.2.x (release 3.2.x)
 2.0.x (release 3.0.x)
 1.3.x (release 2.6.x)
 `),
@@ -115,7 +115,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
-1.2.x (release 3.1.x)
+2.0.x (release 3.2.x)
 1.2.x (release 3.0.x)
 1.0.x (release 2.6.x)
 `),
@@ -139,7 +139,7 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
-1.2.x (release 3.1.x)
+2.0.x (release 3.2.x)
 1.2.x (release 3.0.x)
 1.0.x (release 2.6.x)
 `),
@@ -167,8 +167,8 @@ Hello :smile_cat: This PR contains changelog entries. Please, verify the need of
 			comment: &github.IssueComment{
 				Body: github.String(`
 Hello :smile_cat: This PR contains changelog entries. Please, verify the need of backporting it to the following release branches:
-3.1.x (release 3.1.x) - :robot: :cherries:
-3.0.x (release 3.0.x) - :robot: :cherries:
+3.2.x (release 3.2.x)
+3.0.x (release 3.0.x)
 2.5.x (release 2.6.x)
 `),
 			},

--- a/tests/tests/golden-files/test_issue_comment___pr.yml
+++ b/tests/tests/golden-files/test_issue_comment___pr.yml
@@ -27,7 +27,10 @@ output:
 - info:inventory-enterprise version master is being used in master
 - info:iot-manager version master is being used in master
 - info:mender-artifact version master is being used in master
+- info:mender-binary-delta version master is being used in master
 - info:mender-cli version master is being used in master
+- info:mender-configure-module version master is being used in master
+- info:mender-convert version master is being used in master
 - info:monitor-client version master is being used in master
 - info:mtls-ambassador version master is being used in master
 - info:reporting version master is being used in master
@@ -48,13 +51,14 @@ output:
   DEVICEAUTH_REV:master, DEVICECONFIG_REV:master, DEVICECONNECT_REV:pull/109/head,
   DEVICEMONITOR_REV:pull/12/head, GUI_REV:master, INTEGRATION_REV:pull/1900/head,
   INVENTORY_ENTERPRISE_REV:master, INVENTORY_REV:master, IOT_MANAGER_REV:master, MENDER_ARTIFACT_REV:master,
-  MENDER_CLI_REV:master, MENDER_CONNECT_REV:pull/4/head, MENDER_REV:3.1.x, META_MENDER_REV:pull/1/head,
+  MENDER_BINARY_DELTA_REV:master, MENDER_CLI_REV:master, MENDER_CONFIGURE_MODULE_REV:master,
+  MENDER_CONNECT_REV:pull/4/head, MENDER_CONVERT_REV:master, MENDER_REV:3.1.x, META_MENDER_REV:pull/1/head,
   MONITOR_CLIENT_REV:master, MTLS_AMBASSADOR_REV:master, REPORTING_REV:master, RUN_INTEGRATION_TESTS:true,
   TENANTADM_REV:master, TEST_QEMUX86_64_BIOS_GRUB:, TEST_QEMUX86_64_BIOS_GRUB_GPT:,
   TEST_QEMUX86_64_UEFI_GRUB:, TEST_VEXPRESS_QEMU:, TEST_VEXPRESS_QEMU_FLASH:, TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB:,
   USERADM_ENTERPRISE_REV:master, USERADM_REV:master, WORKFLOWS_ENTERPRISE_REV:master,
   WORKFLOWS_REV:master, '
-- 'gitlab.CreatePipeline: path=Northern.tech/Mender/mender-qa,options={"ref":"master","variables":[{"key":"AUDITLOGS_REV","value":"master"},{"key":"BUILD_BEAGLEBONEBLACK","value":""},{"key":"BUILD_CLIENT","value":"false"},{"key":"BUILD_QEMUX86_64_BIOS_GRUB","value":""},{"key":"BUILD_QEMUX86_64_BIOS_GRUB_GPT","value":""},{"key":"BUILD_QEMUX86_64_UEFI_GRUB","value":""},{"key":"BUILD_VEXPRESS_QEMU","value":""},{"key":"BUILD_VEXPRESS_QEMU_FLASH","value":""},{"key":"BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":""},{"key":"CREATE_ARTIFACT_WORKER_REV","value":"master"},{"key":"DEPLOYMENTS_ENTERPRISE_REV","value":"master"},{"key":"DEPLOYMENTS_REV","value":"master"},{"key":"DEVICEAUTH_ENTERPRISE_REV","value":"master"},{"key":"DEVICEAUTH_REV","value":"master"},{"key":"DEVICECONFIG_REV","value":"master"},{"key":"DEVICECONNECT_REV","value":"pull/109/head"},{"key":"DEVICEMONITOR_REV","value":"pull/12/head"},{"key":"GUI_REV","value":"master"},{"key":"INTEGRATION_REV","value":"pull/1900/head"},{"key":"INVENTORY_ENTERPRISE_REV","value":"master"},{"key":"INVENTORY_REV","value":"master"},{"key":"IOT_MANAGER_REV","value":"master"},{"key":"MENDER_ARTIFACT_REV","value":"master"},{"key":"MENDER_CLI_REV","value":"master"},{"key":"MENDER_CONNECT_REV","value":"pull/4/head"},{"key":"MENDER_REV","value":"3.1.x"},{"key":"META_MENDER_REV","value":"pull/1/head"},{"key":"MONITOR_CLIENT_REV","value":"master"},{"key":"MTLS_AMBASSADOR_REV","value":"master"},{"key":"REPORTING_REV","value":"master"},{"key":"RUN_INTEGRATION_TESTS","value":"true"},{"key":"TENANTADM_REV","value":"master"},{"key":"TEST_QEMUX86_64_BIOS_GRUB","value":""},{"key":"TEST_QEMUX86_64_BIOS_GRUB_GPT","value":""},{"key":"TEST_QEMUX86_64_UEFI_GRUB","value":""},{"key":"TEST_VEXPRESS_QEMU","value":""},{"key":"TEST_VEXPRESS_QEMU_FLASH","value":""},{"key":"TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":""},{"key":"USERADM_ENTERPRISE_REV","value":"master"},{"key":"USERADM_REV","value":"master"},{"key":"WORKFLOWS_ENTERPRISE_REV","value":"master"},{"key":"WORKFLOWS_REV","value":"master"}]}'
+- 'gitlab.CreatePipeline: path=Northern.tech/Mender/mender-qa,options={"ref":"master","variables":[{"key":"AUDITLOGS_REV","value":"master"},{"key":"BUILD_BEAGLEBONEBLACK","value":""},{"key":"BUILD_CLIENT","value":"false"},{"key":"BUILD_QEMUX86_64_BIOS_GRUB","value":""},{"key":"BUILD_QEMUX86_64_BIOS_GRUB_GPT","value":""},{"key":"BUILD_QEMUX86_64_UEFI_GRUB","value":""},{"key":"BUILD_VEXPRESS_QEMU","value":""},{"key":"BUILD_VEXPRESS_QEMU_FLASH","value":""},{"key":"BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":""},{"key":"CREATE_ARTIFACT_WORKER_REV","value":"master"},{"key":"DEPLOYMENTS_ENTERPRISE_REV","value":"master"},{"key":"DEPLOYMENTS_REV","value":"master"},{"key":"DEVICEAUTH_ENTERPRISE_REV","value":"master"},{"key":"DEVICEAUTH_REV","value":"master"},{"key":"DEVICECONFIG_REV","value":"master"},{"key":"DEVICECONNECT_REV","value":"pull/109/head"},{"key":"DEVICEMONITOR_REV","value":"pull/12/head"},{"key":"GUI_REV","value":"master"},{"key":"INTEGRATION_REV","value":"pull/1900/head"},{"key":"INVENTORY_ENTERPRISE_REV","value":"master"},{"key":"INVENTORY_REV","value":"master"},{"key":"IOT_MANAGER_REV","value":"master"},{"key":"MENDER_ARTIFACT_REV","value":"master"},{"key":"MENDER_BINARY_DELTA_REV","value":"master"},{"key":"MENDER_CLI_REV","value":"master"},{"key":"MENDER_CONFIGURE_MODULE_REV","value":"master"},{"key":"MENDER_CONNECT_REV","value":"pull/4/head"},{"key":"MENDER_CONVERT_REV","value":"master"},{"key":"MENDER_REV","value":"3.1.x"},{"key":"META_MENDER_REV","value":"pull/1/head"},{"key":"MONITOR_CLIENT_REV","value":"master"},{"key":"MTLS_AMBASSADOR_REV","value":"master"},{"key":"REPORTING_REV","value":"master"},{"key":"RUN_INTEGRATION_TESTS","value":"true"},{"key":"TENANTADM_REV","value":"master"},{"key":"TEST_QEMUX86_64_BIOS_GRUB","value":""},{"key":"TEST_QEMUX86_64_BIOS_GRUB_GPT","value":""},{"key":"TEST_QEMUX86_64_UEFI_GRUB","value":""},{"key":"TEST_VEXPRESS_QEMU","value":""},{"key":"TEST_VEXPRESS_QEMU_FLASH","value":""},{"key":"TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":""},{"key":"USERADM_ENTERPRISE_REV","value":"master"},{"key":"USERADM_REV","value":"master"},{"key":"WORKFLOWS_ENTERPRISE_REV","value":"master"},{"key":"WORKFLOWS_REV","value":"master"}]}'
 - 'info:Created pipeline: '
 - 'github.CreateComment: org=mendersoftware,repo=deviceconnect,number=109,comment={"body":"\nHello
   :smile_cat: I created a pipeline for you here: [Pipeline-0]()\n\n\u003cdetails\u003e\n    \u003csummary\u003eBuild
@@ -65,9 +69,10 @@ output:
   | master |\n| DEVICECONNECT_REV | pull/109/head |\n| DEVICEMONITOR_REV | pull/12/head
   |\n| GUI_REV | master |\n| INTEGRATION_REV | pull/1900/head |\n| INVENTORY_ENTERPRISE_REV
   | master |\n| INVENTORY_REV | master |\n| IOT_MANAGER_REV | master |\n| MENDER_ARTIFACT_REV
-  | master |\n| MENDER_CLI_REV | master |\n| MENDER_CONNECT_REV | pull/4/head |\n|
-  MENDER_REV | 3.1.x |\n| META_MENDER_REV | pull/1/head |\n| MONITOR_CLIENT_REV |
-  master |\n| MTLS_AMBASSADOR_REV | master |\n| REPORTING_REV | master |\n| RUN_INTEGRATION_TESTS
-  | true |\n| TENANTADM_REV | master |\n| USERADM_ENTERPRISE_REV | master |\n| USERADM_REV
-  | master |\n| WORKFLOWS_ENTERPRISE_REV | master |\n| WORKFLOWS_REV | master |\n\n\n
-  \u003c/p\u003e\u003c/details\u003e\n"}'
+  | master |\n| MENDER_BINARY_DELTA_REV | master |\n| MENDER_CLI_REV | master |\n|
+  MENDER_CONFIGURE_MODULE_REV | master |\n| MENDER_CONNECT_REV | pull/4/head |\n|
+  MENDER_CONVERT_REV | master |\n| MENDER_REV | 3.1.x |\n| META_MENDER_REV | pull/1/head
+  |\n| MONITOR_CLIENT_REV | master |\n| MTLS_AMBASSADOR_REV | master |\n| REPORTING_REV
+  | master |\n| RUN_INTEGRATION_TESTS | true |\n| TENANTADM_REV | master |\n| USERADM_ENTERPRISE_REV
+  | master |\n| USERADM_REV | master |\n| WORKFLOWS_ENTERPRISE_REV | master |\n| WORKFLOWS_REV
+  | master |\n\n\n \u003c/p\u003e\u003c/details\u003e\n"}'

--- a/tests/tests/golden-files/test_pull_request_closed.yml
+++ b/tests/tests/golden-files/test_pull_request_closed.yml
@@ -30,8 +30,11 @@ output:
 - info:iot-manager version master is being used in master
 - info:mender version master is being used in master
 - info:mender-artifact version master is being used in master
+- info:mender-binary-delta version master is being used in master
 - info:mender-cli version master is being used in master
+- info:mender-configure-module version master is being used in master
 - info:mender-connect version master is being used in master
+- info:mender-convert version master is being used in master
 - info:monitor-client version master is being used in master
 - info:mtls-ambassador version master is being used in master
 - info:reporting version master is being used in master


### PR DESCRIPTION
Previously cherry-picks were only supported in release branches matching some
release version, like `1.2.x`.

Now, this functionality is extended to the standard branchnames, like:

* master
* hosted
* staging
* production

Changelog: None
Signed-off-by: Ole Petter <ole.orhagen@northern.tech>