### PR TITLE
chore: Use complete version for the Docker base images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
-FROM golang:1.14-alpine3.11 as builder
+FROM golang:1.14.15-alpine3.11 as builder
 RUN mkdir -p /go/src/github.com/mendersoftware/integration-test-runner
 WORKDIR /go/src/github.com/mendersoftware/integration-test-runner
 ADD ./ .
 RUN CGO_ENABLED=0 go build
 
-FROM golang:1.14-alpine3.11
+FROM golang:1.14.15-alpine3.11
 EXPOSE 8080
 RUN apk add git openssh python3 py3-pip
 RUN pip3 install --upgrade pyyaml PyGithub

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -1,10 +1,10 @@
-FROM golang:1.14-alpine3.11 as builder
+FROM golang:1.14.15-alpine3.11 as builder
 RUN mkdir -p /go/src/github.com/mendersoftware/integration-test-runner
 WORKDIR /go/src/github.com/mendersoftware/integration-test-runner
 ADD ./ .
 RUN CGO_ENABLED=0 go test -c -o integration-test-runner -coverpkg $(go list ./... | grep -v mocks | grep -v /test | tr  '\n' ,)
 
-FROM golang:1.14-alpine3.11
+FROM golang:1.14.15-alpine3.11
 EXPOSE 8080
 RUN apk add git openssh python3 py3-pip
 RUN pip3 install --upgrade pyyaml PyGithub


### PR DESCRIPTION
For some reason dependabot concludes that "Latest version is 1.14-alpine3.11" when parsing the `Dockerfile`, which I suspect is due to the bugfix version not being present.