### PR TITLE
fix: Prevent warnings from causing changelog reposting.

### DIFF
--- a/integration_helpers.go
+++ b/integration_helpers.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os/exec"
 	"path"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -46,7 +47,17 @@ func getChangelogText(repo, versionRange string, conf *config) (stdout,
 		"--github-repo", repo,
 		versionRange,
 	)
-	return getBothStdoutAndStderr(c)
+	stdout, stderr, retErr = getBothStdoutAndStderr(c)
+
+	// Replace commit IDs in warnings, to avoid multiple postings when they
+	// change.
+	matcher, err := regexp.Compile("Commit [0-9a-f]{40} had a number")
+	if err == nil {
+		stderr = matcher.ReplaceAllString(stderr,
+			"One commit had a number")
+	}
+
+	return stdout, stderr, retErr
 }
 
 // All this because exec doesn't have a SplitOutputs() function...

--- a/integration_helpers_test.go
+++ b/integration_helpers_test.go
@@ -58,7 +58,7 @@ New changes in mender since 3.0.0:
 `
 	assert.Equal(t, expected, stdout)
 
-	expected = `*** Commit a4b451ec1f32ee32e8ba1ac51c602c97069dd1d0 had a number 0000 which may be a ticket reference we missed. Should be manually checked.
+	expected = `*** One commit had a number 0000 which may be a ticket reference we missed. Should be manually checked.
 ---
 Add missing filesystem sync after populating Update Module's file tree.
 


### PR DESCRIPTION
Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>