### PR TITLE
INF-3042: ci: don't update repos-sync.cfengine.com to latest version

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,4 +93,4 @@ publish:acceptance:
 
 sync:image:
   variables:
-    TARGET_MANIFEST_FILE: "kubernetes/mender-test-runner/test-runner-deployment.yaml,kubernetes/cfengine-repos-sync/repos-sync-cfengine-com-deployment.yaml"
+    TARGET_MANIFEST_FILE: "kubernetes/mender-test-runner/test-runner-deployment.yaml"


### PR DESCRIPTION
It's a workaround to address CFEngine team complaines about latest changes in integration-test-runner functionality, until required functionality is in place.

Changelog: None
Ticket: INF-3042
Signed-off-by: Alex Miliukov <oleksandr.miliukov@northern.tech>