### PR TITLE
QA-518: add list of repos to sync option

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,21 +2,20 @@
 
 ## Main features
 
-### `mender-qa` Pipeline run
-
-Set `WATCH_REPOS_PIPELINE` for the list of repositories for which to run
-`mender-qa` Pipeline. See source code for defaults.
-
-This is a Mender specific feature.
-
 ### GitHub -> GitLab sync
 
-All repositories from the configured GitHub organization are synced with GitLab.
+By default all repositories from the configured GitHub organization are synced with GitLab. To select a subset of repositories to sync, set `SYNC_REPOS_LIST` env variable with a comma separated list of repositories.
 
 ### GitLab PR branches
 
-For all repositories in the organization, a pr_XXX branch will be created in
-GitLab for every pull/XXX PR from GitHub.
+For all repositories in the organization, a pr_XXX branch will be created in GitLab for every pull/XXX PR from GitHub.
+
+### Processing GitHub events
+
+Currently the following GitHub events are processed:
+* `pull_request`: enabled by default, `DISABLE_PR_EVENTS_PROCESSING` disables the processing
+* `push`: enabled by default, `DISABLE_PUSH_EVENTS_PROCESSING` disables the processing
+* `issue_comment`: enabled by default, `DISABLE_COMMENT_EVENTS_PROCESSING` disables the processing
 
 ## Infrastructure
 

--- a/main_push.go
+++ b/main_push.go
@@ -21,9 +21,22 @@ func processGitHubPush(
 
 	log.Debugf("Got push event :: repo %s :: ref %s", repoName, refName)
 
-	err := syncRemoteRef(log, repoOrg, repoName, refName, conf)
-	if err != nil {
-		log.Errorf("Could not sync branch: %s", err.Error())
+	if len(conf.reposSyncList) == 0 || isRepoManaged(repoName, conf.reposSyncList) {
+		log.Debugf("Syncing repo %s/%s", repoOrg, repoName)
+		err := syncRemoteRef(log, repoOrg, repoName, refName, conf)
+		if err != nil {
+			log.Errorf("Could not sync branch: %s", err.Error())
+			return err
+		}
 	}
-	return err
+	return nil
+}
+
+func isRepoManaged(repo string, reposList []string) bool {
+	for _, r := range reposList {
+		if r == repo {
+			return true
+		}
+	}
+	return false
 }

--- a/tests/tests/golden-files/test_push_cfengine.yml
+++ b/tests/tests/golden-files/test_push_cfengine.yml
@@ -1,6 +1,7 @@
 input: push_cfengine.json
 output:
 - 'debug:Got push event :: repo website :: ref refs/heads/master'
+- debug:Syncing repo cfengine/website
 - 'git.Run: /usr/bin/git init .'
 - 'git.Run: /usr/bin/git remote add github git@github.com:/cfengine/website.git'
 - 'git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/CFEngine/website'

--- a/tests/tests/golden-files/test_push_mender_qa_repo.yml
+++ b/tests/tests/golden-files/test_push_mender_qa_repo.yml
@@ -1,6 +1,7 @@
 input: push_mender_qa_repo.json
 output:
 - 'debug:Got push event :: repo mender-qa :: ref refs/heads/master'
+- debug:Syncing repo mendersoftware/mender-qa
 - 'git.Run: /usr/bin/git init .'
 - 'git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/mender-qa.git'
 - 'git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/mender-qa'

--- a/tests/tests/golden-files/test_push_mendersoftware.yml
+++ b/tests/tests/golden-files/test_push_mendersoftware.yml
@@ -1,6 +1,7 @@
 input: push.json
 output:
 - 'debug:Got push event :: repo workflows-enterprise :: ref refs/heads/master'
+- debug:Syncing repo mendersoftware/workflows-enterprise
 - 'git.Run: /usr/bin/git init .'
 - 'git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/workflows-enterprise.git'
 - 'git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/workflows-enterprise'


### PR DESCRIPTION
Ticket: [QA-518](https://tracker.mender.io/browse/QA-518)

With the change the following is achieved:
* it's possible to disable different features if some is not needed
* it's possible to set a list of managed repos and ignore the rest

The change is backward compatible and won't brake current deployments, but will allow to customise a deployment for CFEngine GitHub organisation.

Straight goal is to use the integration-test-runner to only sync specified list of repos for CFEngine GitHub organisation. With the implementation it can be achieved with using the following setup: `SYNC_REPOS_LIST="website,build"`, `NOT_PROCESS_PR_EVENTS="true"` and `NOT_PROCESS_COMMENTS="true"`