### PR TITLE
fix: Do not process edited pull requests

### DIFF
--- a/main_pullrequest.go
+++ b/main_pullrequest.go
@@ -72,7 +72,7 @@ func processGitHubPullRequest(
 
 	log.Debugf("Processing pull request action %s", action)
 	switch action {
-	case "opened", "edited", "reopened", "synchronize", "ready_for_review":
+	case "opened", "reopened", "synchronize", "ready_for_review":
 		msgDetails := "see <a href=\"https://console.cloud.google.com/kubernetes/" +
 			"deployment/us-east1/company-websites/default/test-runner-mender-io/logs?" +
 			"project=gp-kubernetes-269000\">logs</a> for details."


### PR DESCRIPTION
Dependabot sometimes does a lot of edits in a short timespan. This causes our
test-bot to try and sync the branch on every request, basically doing a simple
DDos of our branch syncing to GitLab.

The fix is simple. Just ignore edits to PR's, which really is the right thing to
do anyways.

Changelog: None
Ticket: QA-538

Signed-off-by: Ole Petter <ole.orhagen@northern.tech>