### PR TITLE
chore: Add missing newline in comment for proper markdown rendering

### DIFF
--- a/main_pullrequest.go
+++ b/main_pullrequest.go
@@ -185,6 +185,7 @@ func processGitHubPullRequest(
    <details>
    <summary>my commands and options</summary>
    <br />
+
    You can trigger a pipeline on multiple prs with:
    - mentioning me and ` + "`" + `start pipeline --pr mender/127 --pr mender-connect/255` + "`" + `
 


### PR DESCRIPTION
Otherwise GH takes the next line after `<br />` as raw text.