### PR TITLE
fix: Allow cherry-pick of empty commits

### DIFF
--- a/cherrypicks.go
+++ b/cherrypicks.go
@@ -237,7 +237,7 @@ func tryCherryPickToBranch(
 		return "", state, err
 	}
 
-	if err = git.Command("cherry-pick", "-x",
+	if err = git.Command("cherry-pick", "-x", "--allow-empty",
 		pr.GetHead().GetSHA(), "^"+pr.GetBase().GetSHA()).
 		With(state).Run(); err != nil {
 		if strings.Contains(err.Error(), "conflict") {

--- a/tests/tests/golden-files/test_cherrypick_multiline.yml
+++ b/tests/tests/golden-files/test_cherrypick_multiline.yml
@@ -7,7 +7,7 @@ output:
 - 'git.Run: /usr/bin/git fetch mendersoftware'
 - 'git.Run: /usr/bin/git checkout mendersoftware/3.1.x'
 - 'git.Run: /usr/bin/git checkout -b cherry-3.1.x-logbuffering'
-- 'git.Run: /usr/bin/git cherry-pick -x f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
+- 'git.Run: /usr/bin/git cherry-pick -x --allow-empty f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
 - 'git.Run: /usr/bin/git push mendersoftware cherry-3.1.x-logbuffering:cherry-3.1.x-logbuffering'
 - 'github.CreatePullRequest: org=mendersoftware,repo=mender,pr={"title":"[Cherry 3.1.x]:
   MEN-5098: Capture and pretty print output from scripts executed","head":"cherry-3.1.x-logbuffering","base":"3.1.x","body":"Cherry
@@ -17,7 +17,7 @@ output:
 - 'git.Run: /usr/bin/git fetch mendersoftware'
 - 'git.Run: /usr/bin/git checkout mendersoftware/3.0.x'
 - 'git.Run: /usr/bin/git checkout -b cherry-3.0.x-logbuffering'
-- 'git.Run: /usr/bin/git cherry-pick -x f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
+- 'git.Run: /usr/bin/git cherry-pick -x --allow-empty f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
 - 'git.Run: /usr/bin/git push mendersoftware cherry-3.0.x-logbuffering:cherry-3.0.x-logbuffering'
 - 'github.CreatePullRequest: org=mendersoftware,repo=mender,pr={"title":"[Cherry 3.0.x]:
   MEN-5098: Capture and pretty print output from scripts executed","head":"cherry-3.0.x-logbuffering","base":"3.0.x","body":"Cherry
@@ -27,7 +27,7 @@ output:
 - 'git.Run: /usr/bin/git fetch mendersoftware'
 - 'git.Run: /usr/bin/git checkout mendersoftware/2.6.x'
 - 'git.Run: /usr/bin/git checkout -b cherry-2.6.x-logbuffering'
-- 'git.Run: /usr/bin/git cherry-pick -x f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
+- 'git.Run: /usr/bin/git cherry-pick -x --allow-empty f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
 - 'git.Run: /usr/bin/git push mendersoftware cherry-2.6.x-logbuffering:cherry-2.6.x-logbuffering'
 - 'github.CreatePullRequest: org=mendersoftware,repo=mender,pr={"title":"[Cherry 2.6.x]:
   MEN-5098: Capture and pretty print output from scripts executed","head":"cherry-2.6.x-logbuffering","base":"2.6.x","body":"Cherry

--- a/tests/tests/golden-files/test_cherrypick_singleline.yml
+++ b/tests/tests/golden-files/test_cherrypick_singleline.yml
@@ -7,7 +7,7 @@ output:
 - 'git.Run: /usr/bin/git fetch mendersoftware'
 - 'git.Run: /usr/bin/git checkout mendersoftware/3.1.x'
 - 'git.Run: /usr/bin/git checkout -b cherry-3.1.x-logbuffering'
-- 'git.Run: /usr/bin/git cherry-pick -x f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
+- 'git.Run: /usr/bin/git cherry-pick -x --allow-empty f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
 - 'git.Run: /usr/bin/git push mendersoftware cherry-3.1.x-logbuffering:cherry-3.1.x-logbuffering'
 - 'github.CreatePullRequest: org=mendersoftware,repo=mender,pr={"title":"[Cherry 3.1.x]:
   MEN-5098: Capture and pretty print output from scripts executed","head":"cherry-3.1.x-logbuffering","base":"3.1.x","body":"Cherry
@@ -17,7 +17,7 @@ output:
 - 'git.Run: /usr/bin/git fetch mendersoftware'
 - 'git.Run: /usr/bin/git checkout mendersoftware/3.0.x'
 - 'git.Run: /usr/bin/git checkout -b cherry-3.0.x-logbuffering'
-- 'git.Run: /usr/bin/git cherry-pick -x f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
+- 'git.Run: /usr/bin/git cherry-pick -x --allow-empty f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
 - 'git.Run: /usr/bin/git push mendersoftware cherry-3.0.x-logbuffering:cherry-3.0.x-logbuffering'
 - 'github.CreatePullRequest: org=mendersoftware,repo=mender,pr={"title":"[Cherry 3.0.x]:
   MEN-5098: Capture and pretty print output from scripts executed","head":"cherry-3.0.x-logbuffering","base":"3.0.x","body":"Cherry
@@ -27,7 +27,7 @@ output:
 - 'git.Run: /usr/bin/git fetch mendersoftware'
 - 'git.Run: /usr/bin/git checkout mendersoftware/2.6.x'
 - 'git.Run: /usr/bin/git checkout -b cherry-2.6.x-logbuffering'
-- 'git.Run: /usr/bin/git cherry-pick -x f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
+- 'git.Run: /usr/bin/git cherry-pick -x --allow-empty f48250b19fae7ba72de2439c20a0fc678afa9a87 ^4c6d93ba936031ee00d9c115ef2dc61597bc1296'
 - 'git.Run: /usr/bin/git push mendersoftware cherry-2.6.x-logbuffering:cherry-2.6.x-logbuffering'
 - 'github.CreatePullRequest: org=mendersoftware,repo=mender,pr={"title":"[Cherry 2.6.x]:
   MEN-5098: Capture and pretty print output from scripts executed","head":"cherry-2.6.x-logbuffering","base":"2.6.x","body":"Cherry


### PR DESCRIPTION
Make the bot behave when cherry-picking empty commits, for example when amending changelog entries.