### PR TITLE
fix: Remove duplicated pipeline for `meta-mender` PRs

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,12 +44,6 @@ type buildOptions struct {
 	makeQEMU   bool
 }
 
-// List of repos besides the ones in release_tool.py for
-// which the integration pipeline shall be run
-var extraWatchRepositoriesPipeline = []string{
-	"meta-mender",
-}
-
 // Mapping https://github.com/<org> -> https://gitlab.com/Northern.tech/<group>
 var gitHubOrganizationToGitLabGroup = map[string]string{
 	"mendersoftware": "Mender",

--- a/menderqa_pipeline.go
+++ b/menderqa_pipeline.go
@@ -89,12 +89,12 @@ func getBuilds(log *logrus.Entry, conf *config, pr *github.PullRequestEvent) []b
 		log.Warnf(err.Error())
 	}
 
-	watchRepositoriesTriggerPipeline, err := getListOfWatchedRepositories(conf)
+	allRepositories, err := getListOfAllRepositories(conf)
 	if err != nil {
 		log.Warnf(err.Error())
 	}
 
-	for _, watchRepo := range watchRepositoriesTriggerPipeline {
+	for _, watchRepo := range allRepositories {
 		// make sure the repo that the pull request is performed against is
 		// one that we are watching.
 

--- a/menderqa_pipeline_helpers.go
+++ b/menderqa_pipeline_helpers.go
@@ -114,13 +114,3 @@ func getListOfAllRepositories(conf *config) ([]string, error) {
 
 	return strings.Split(strings.TrimSpace(string(output)), "\n"), nil
 }
-
-func getListOfWatchedRepositories(conf *config) ([]string, error) {
-
-	listOfAllRepositories, err := getListOfAllRepositories(conf)
-	if err != nil {
-		return nil, err
-	}
-
-	return append(listOfAllRepositories, extraWatchRepositoriesPipeline...), nil
-}


### PR DESCRIPTION
Originally this repository was not part of the release tool so it was appended as an extra repo to the watch list. However it was added to the tool at some point and now we were having two identical pipelines on PRs for this repository.