### PR TITLE
ci: move from public to self-hosted runners

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -38,7 +38,7 @@ test:unit:
 test:acceptance_tests:
   stage: test
   tags:
-    - docker
+    - hetzner-amd-beefy
   image: tiangolo/docker-with-compose
   services:
     - docker:dind


### PR DESCRIPTION
Public runners are considered not secure; moving to self-hosted runners instead. Additionally, the docker runner tag is no longer available.

Ticket: SEC-1133
Changelog: None