### PR TITLE
chore: bump golang-image versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
-FROM golang:1.20.4-alpine3.16 AS builder
+FROM golang:1.23.4-alpine3.21 AS builder
 RUN mkdir -p /go/src/github.com/mendersoftware/integration-test-runner
 WORKDIR /go/src/github.com/mendersoftware/integration-test-runner
 ADD ./ .
 RUN CGO_ENABLED=0 go build
 
-FROM golang:1.20.4-alpine3.16
+FROM golang:1.23.4-alpine3.21
 EXPOSE 8080
 RUN apk add git openssh python3 py3-pip
-RUN pip3 install --upgrade pyyaml PyGithub
+RUN pip3 install --upgrade pyyaml PyGithub --break-system-packages
 RUN mkdir -p /root/.ssh
 RUN git clone https://github.com/mendersoftware/integration.git /integration
 ENV PATH="/integration/extra:${PATH}"

--- a/Dockerfile.acceptance
+++ b/Dockerfile.acceptance
@@ -1,13 +1,13 @@
-FROM golang:1.20.4-alpine3.16 AS builder
+FROM golang:1.23.4-alpine3.21 AS builder
 RUN mkdir -p /go/src/github.com/mendersoftware/integration-test-runner
 WORKDIR /go/src/github.com/mendersoftware/integration-test-runner
 ADD ./ .
 RUN CGO_ENABLED=0 go test -c -o integration-test-runner -coverpkg $(go list ./... | grep -v mocks | grep -v /test | tr  '\n' ,)
 
-FROM golang:1.20.4-alpine3.16
+FROM golang:1.23.4-alpine3.21
 EXPOSE 8080
 RUN apk add git openssh python3 py3-pip
-RUN pip3 install --upgrade pyyaml PyGithub
+RUN pip3 install --upgrade pyyaml PyGithub --break-system-packages
 RUN mkdir -p /root/.ssh
 RUN git clone https://github.com/mendersoftware/integration.git /integration
 ENV PATH="/integration/extra:${PATH}"


### PR DESCRIPTION
We need a newer golang version in the unit tests, because go now allows patch-versions for the go version in the go.mod - which some newer dependencies require.

We also need this https://github.com/mendersoftware/mendertesting/pull/358