### PR TITLE
chore: Remove mender-server from entfork_sync

### DIFF
--- a/entfork_sync.go
+++ b/entfork_sync.go
@@ -39,7 +39,6 @@ func syncIfOSHasEnterpriseRepo(
 	case "useradm":
 	case "workflows":
 	case "deviceauth":
-	case "mender-server":
 	default:
 		log.Debugf(
 			"syncIfOSHasEnterpriseRepo: Repository without Enterprise fork detected: (%s). "+


### PR DESCRIPTION
The sync is managed through Gitlab CI