### PR TITLE
SEC-1473: feat: Support for cryptographically sign Git commits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN CGO_ENABLED=0 go build
 
 FROM golang:1.23.5-alpine3.21
 EXPOSE 8080
-RUN apk add git openssh python3 py3-pip
+RUN apk add git openssh python3 py3-pip gpg gpg-agent
 RUN pip3 install --upgrade pyyaml PyGithub --break-system-packages
 RUN mkdir -p /root/.ssh
 RUN git clone https://github.com/mendersoftware/integration.git /integration

--- a/entrypoint
+++ b/entrypoint
@@ -1,7 +1,7 @@
 #!/bin/sh
 
-git config --global user.name ${GIT_CONFIG_USER_NAME-Mender Root}
-git config --global user.email ${GIT_CONFIG_USER_EMAIL-root@mender-jenkins.mender.io}
+git config --global user.name "${GIT_CONFIG_USER_NAME-Mender Test Bot}"
+git config --global user.email ${GIT_CONFIG_USER_EMAIL-mender@northern.tech}
 
 ssh-keyscan github.com >> /root/.ssh/known_hosts
 ssh-keyscan gitlab.com >> /root/.ssh/known_hosts

--- a/entrypoint
+++ b/entrypoint
@@ -6,4 +6,10 @@ git config --global user.email ${GIT_CONFIG_USER_EMAIL-mender@northern.tech}
 ssh-keyscan github.com >> /root/.ssh/known_hosts
 ssh-keyscan gitlab.com >> /root/.ssh/known_hosts
 
+# If a GPG key was mounted into the container, import it and configure Git to use it
+if [ -f "/root/gpg_key" ]; then
+    gpg --import /root/gpg_key
+    echo -e "[commit]\n\tgpgsign = true" >> ~/.gitconfig
+fi
+
 exec /integration-test-runner


### PR DESCRIPTION
We opted for not modifying the `git` commands from the source code and instead just externally configure Git to always sign commits.

With this approach we let the different deployments of this software to opt-in the feature (by mounting the required secret) but let the software run without it otherwise.