### PR TITLE
Fix delete

### DIFF
--- a/main_comment.go
+++ b/main_comment.go
@@ -214,7 +214,7 @@ func syncProtectedBranch(
 	prBranchName := "pr_" + strconv.Itoa(pr.GetNumber()) + "_protected"
 
 	// check if we have a protected branch and try to delete it
-	response, err := deletePRBranch(pr, conf, fmt.Sprintf("pr_%d_protected", pr.GetNumber()), log)
+	response, err := deletePRBranch(pr, conf, prBranchName, log)
 	if err != nil {
 		// Don't return error if the branch doesn't exist
 		if response.StatusCode != 404 {

--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -210,10 +210,11 @@ func deletePRBranch(
 
 	repoName := pr.GetRepo().GetName()
 
-	remoteURL, err := getRemoteURLGitLab(conf.githubOrganization, repoName)
-	if err != nil {
-		return nil, err
+	group, ok := gitHubOrganizationToGitLabGroup[conf.githubOrganization]
+	if !ok {
+		return nil, fmt.Errorf("Unrecognized organization %q", conf.githubOrganization)
 	}
+	path := "Northern.tech/" + group + "/" + repoName
 
 	client, err := clientgitlab.NewGitLabClient(
 		conf.gitlabToken,
@@ -224,7 +225,7 @@ func deletePRBranch(
 		return nil, err
 	}
 
-	response, err := client.DeleteBranch(remoteURL, prBranchName, nil)
+	response, err := client.DeleteBranch(path, prBranchName, nil)
 	if err != nil {
 		return response, err
 	}

--- a/tests/tests/golden-files/test_issue_comment_integration.yml
+++ b/tests/tests/golden-files/test_issue_comment_integration.yml
@@ -1,7 +1,7 @@
 input: issue_comment_integration.json
 output:
 - 'github.IsOrganizationMember: org=mendersoftware,user=lluiscampos'
-- 'gitlab.DeleteBranch: path=git@gitlab.com:Northern.tech/Mender/integration,branch=pr_2725_protected'
+- 'gitlab.DeleteBranch: path=Northern.tech/Mender/integration,branch=pr_2725_protected'
 - 'git.Run: /usr/bin/git init .'
 - 'git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/integration.git'
 - 'git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/integration'

--- a/tests/tests/golden-files/test_pull_request_closed.yml
+++ b/tests/tests/golden-files/test_pull_request_closed.yml
@@ -1,7 +1,7 @@
 input: pull_request_closed.json
 output:
 - debug:Processing pull request action closed
-- 'gitlab.DeleteBranch: path=git@gitlab.com:Northern.tech/Mender/mender-configure-module,branch=pr_145'
+- 'gitlab.DeleteBranch: path=Northern.tech/Mender/mender-configure-module,branch=pr_145'
 - 'info:Ignoring cherry-pick suggestions for action: closed, merged: false'
 - 'github.IsOrganizationMember: org=mendersoftware,user=lluiscampos'
 - 'debug:stopBuildsOfStaleClientPRs: Find any running pipelines and kill mercilessly!'


### PR DESCRIPTION
The fix should be best illustrated in the output from the golden files:


Before:  `gitlab.DeleteBranch: path=git@gitlab.com:Northern.tech/Mender/integration,branch=pr_2725_protected`
Now: `gitlab.DeleteBranch: path=Northern.tech/Mender/integration,branch=pr_2725_protected`

I am pretty sure that this is why it returned 404 even though the branch existed.