### PR TITLE
fix: attempt to unprotect branches after deleting them

### DIFF
--- a/client/gitlab/client.go
+++ b/client/gitlab/client.go
@@ -18,6 +18,11 @@ type Client interface {
 		path string,
 		options *gitlab.ProtectRepositoryBranchesOptions,
 	) (*gitlab.ProtectedBranch, error)
+	UnprotectRepositoryBranches(
+		path string,
+		branch string,
+		options gitlab.RequestOptionFunc,
+	) (*gitlab.Response, error)
 	ListProjectPipelines(
 		path string,
 		options *gitlab.ListProjectPipelinesOptions,
@@ -126,6 +131,26 @@ func (c *gitLabClient) ProtectRepositoryBranches(
 		options,
 		nil)
 	return protected_branch, err
+}
+
+// UnprotectRepositoryBranches unprotects branches
+func (c *gitLabClient) UnprotectRepositoryBranches(
+	path string,
+	branch string,
+	options gitlab.RequestOptionFunc,
+) (*gitlab.Response, error) {
+	if c.dryRunMode {
+		msg := fmt.Sprintf("gitlab.UnprotectedBranch: path=%s,branch=%s",
+			path, branch,
+		)
+		logger.GetRequestLogger().Push(msg)
+		return nil, nil
+	}
+	response, err := c.client.ProtectedBranches.UnprotectRepositoryBranches(
+		path,
+		branch,
+		options)
+	return response, err
 }
 
 // DeleteBranch deletes branches

--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -229,5 +229,20 @@ func deletePRBranch(
 	if err != nil {
 		return response, err
 	}
+
+	// Deleting the branch does _not_ delete the protection
+	// Attempt to delete the branch protection as well
+	response, err = client.UnprotectRepositoryBranches(
+		path,
+		prBranchName,
+		nil,
+	)
+	if err != nil {
+		// Do not return error if the branch protection doesn't exist
+		if response.StatusCode != 404 {
+			return response, err
+		}
+	}
+
 	return response, nil
 }

--- a/tests/tests/golden-files/test_issue_comment_integration.yml
+++ b/tests/tests/golden-files/test_issue_comment_integration.yml
@@ -2,6 +2,7 @@ input: issue_comment_integration.json
 output:
 - 'github.IsOrganizationMember: org=mendersoftware,user=lluiscampos'
 - 'gitlab.DeleteBranch: path=Northern.tech/Mender/integration,branch=pr_2725_protected'
+- 'gitlab.UnprotectedBranch: path=Northern.tech/Mender/integration,branch=pr_2725_protected'
 - 'git.Run: /usr/bin/git init .'
 - 'git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/integration.git'
 - 'git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/integration'

--- a/tests/tests/golden-files/test_pull_request_closed.yml
+++ b/tests/tests/golden-files/test_pull_request_closed.yml
@@ -2,6 +2,7 @@ input: pull_request_closed.json
 output:
 - debug:Processing pull request action closed
 - 'gitlab.DeleteBranch: path=Northern.tech/Mender/mender-configure-module,branch=pr_145'
+- 'gitlab.UnprotectedBranch: path=Northern.tech/Mender/mender-configure-module,branch=pr_145'
 - 'info:Ignoring cherry-pick suggestions for action: closed, merged: false'
 - 'github.IsOrganizationMember: org=mendersoftware,user=lluiscampos'
 - 'debug:stopBuildsOfStaleClientPRs: Find any running pipelines and kill mercilessly!'


### PR DESCRIPTION
Just deleting the branch will still leave the protection rule in Gitlab. When attempting to sync a branch while the protection is there, we will get 409 conflict errors. Therefore we want to unprotect the branch after deleting it to ensure we can re-create it and that the protection rule is deleted after closing / merging a PR.

Changelog: None
Ticket: None