### PR TITLE
fix: wait between deletion and syncing branches

### DIFF
--- a/main_comment.go
+++ b/main_comment.go
@@ -222,6 +222,9 @@ func syncProtectedBranch(
 				response.StatusCode, err.Error())
 		}
 	}
+	// Arbitrary sleep to ensure the branch and protection
+	// is fully deleted before we sync
+	time.Sleep(time.Duration(5) * time.Second)
 	if err := syncBranch(prBranchName, log, pr, conf); err != nil {
 		mainErrMsg := "There was an error syncing branches"
 		return "", fmt.Errorf("%v returned error: %s: %s", err, mainErrMsg, err.Error())


### PR DESCRIPTION
See the latest runs here: https://github.com/mendersoftware/integration/pull/2730
It works sometimes, and (seemingly) always after closing and re-opening the pr. This leads me to believe the syncing sometimes happens before the deletion has completed, giving errors like:

```There was an error while syncing branches: [push -f -o ci.skip --set-upstream gitlab pr_2730_protected] returned error: remote: GitLab: You are not allowed to create protected branches on this project.
To gitlab.com:Northern.tech/Mender/integration
! [remote rejected] pr_2730_protected -> pr_2730_protected (pre-receive hook declined)
error: failed to push some refs to 'gitlab.com:Northern.tech/Mender/integration'
: exit status 1 returned error: There was an error syncing branches: [push -f -o ci.skip --set-upstream gitlab pr_2730_protected] returned error: remote: GitLab: You are not allowed to create protected branches on this project.
To gitlab.com:Northern.tech/Mender/integration
! [remote rejected] pr_2730_protected -> pr_2730_protected (pre-receive hook declined)
error: failed to push some refs to 'gitlab.com:Northern.tech/Mender/integration'
: exit status 1```