### PR TITLE
fix: correct formatting of bot comment string

### DIFF
--- a/main_pullrequest.go
+++ b/main_pullrequest.go
@@ -203,10 +203,10 @@ func processGitHubPullRequest(
 		var botCommentString string
 		if pr.GetRepo().GetName() == "integration" {
 			botCommentString = `, start a full integration test pipeline with:
-   - mentioning me and ` + "`" + `start integration pipeline` + "`" + ``
+   - mentioning me and ` + "`" + commandStartIntegrationPipeline + "`"
 		} else {
 			botCommentString = `, start a full client pipeline with:
-   - mentioning me and ` + "`" + commandStartClientPipeline + `"`
+   - mentioning me and ` + "`" + commandStartClientPipeline + "`"
 		}
 
 		if getFirstMatchingBotCommentInPR(log, githubClient, pr, botCommentString, conf) == nil {


### PR DESCRIPTION
Client pipelines now print:
`mentioning me and `start client pipeline"start client pipeline".`

This seems to be caused by a mixed use of backticks and double quotes: "`" + commandStartClientPipeline + `"`.

Updated the integration pipeline comment to use the `commandStartIntegrationPipeline` variable instead of hardcoding the string

Ticket: None
Changelog: Title