### PR TITLE
fix: remove extra `commandStartClientPipeline` from bot message

### DIFF
--- a/main_pullrequest.go
+++ b/main_pullrequest.go
@@ -211,8 +211,7 @@ func processGitHubPullRequest(
 
 		if getFirstMatchingBotCommentInPR(log, githubClient, pr, botCommentString, conf) == nil {
 
-			msg := "@" + pr.GetSender().GetLogin() + botCommentString +
-				commandStartClientPipeline + "\"."
+			msg := "@" + pr.GetSender().GetLogin() + botCommentString
 			// nolint:lll
 			msg += `
 


### PR DESCRIPTION
`commandStartClientPipeline` is already a part of `botCommentString`. resulting in `mentioning me and 'start client pipeline'start client pipeline".`

Changelog: None



https://github.com/mendersoftware/integration-test-runner/pull/379 didn't actually address the issue.