### PR TITLE
Accesslogs ignore health checks by default and use consistent format

### DIFF
--- a/main_pullrequest.go
+++ b/main_pullrequest.go
@@ -82,9 +82,9 @@ func processGitHubPullRequest(
 		err    error
 		action = pr.GetAction()
 	)
-	log := getCustomLoggerFromContext(ctx).
-		WithField("pull", pr.GetNumber()).
-		WithField("action", action)
+	ctx.Set("pull", pr.GetNumber())
+	ctx.Set("action", pr.GetAction())
+	log := getCustomLoggerFromContext(ctx)
 	req := pr.GetPullRequest()
 
 	// Do not run if the PR is a draft


### PR DESCRIPTION
Implemented a new access log middleware which outputs logs in the same format. The logger is also consistently logging to stdout instead of logrus logging to stderr and accesslogs going stdout.
Accesslogs additionally contain fields for `delivery` ID and `webhook_type`.