### PR TITLE
fix: reword merge commit and handle stale merge ref

### DIFF
--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/google/go-github/v28/github"
 	"github.com/sirupsen/logrus"
@@ -148,6 +149,55 @@ func syncBranch(
 	}
 
 	gitcmd = git.Command("fetch", "github", "pull/"+prNum+"/merge:"+prBranchName)
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	// GitHub computes pull/NNN/merge asynchronously, webhook can fire before
+	// ref is updated, retry if ^2 doesn't yet match the expected PR head SHA
+	expectedSHA := pr.GetPullRequest().GetHead().GetSHA()
+	for attempt := 1; attempt < 3; attempt++ {
+		gitcmd = git.Command("rev-parse", prBranchName+"^2")
+		gitcmd.Dir = tmpdir
+		actualSHABytes, _ := gitcmd.CombinedOutput()
+		actualSHA := strings.TrimSpace(string(actualSHABytes))
+		if actualSHA == "" || actualSHA == expectedSHA {
+			break
+		}
+		log.Infof("Merge ref pull/%s/merge is stale (got %s, want %s), retrying in 5s (%d/2)",
+			prNum, actualSHA, expectedSHA, attempt)
+		time.Sleep(5 * time.Second)
+		gitcmd = git.Command("fetch", "github", "-f", "pull/"+prNum+"/merge:"+prBranchName)
+		gitcmd.Dir = tmpdir
+		out, err = gitcmd.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+		}
+	}
+
+	// The merge commit's second parent is the PR head commit — use its message so
+	// GitLab shows the original PR commit subject instead of "Merge <sha> into ..."
+	gitcmd = git.Command("log", "-1", "--format=%B", prBranchName+"^2")
+	gitcmd.Dir = tmpdir
+	headMsg, err := gitcmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, headMsg, err.Error())
+	}
+
+	gitcmd = git.Command("checkout", prBranchName)
+	gitcmd.Dir = tmpdir
+	out, err = gitcmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
+	}
+
+	gitcmd = git.Command(
+		"-c", "user.email=mender-test-bot@northern.tech",
+		"-c", "user.name=Mender Test Runner",
+		"commit", "--amend", "-m", strings.TrimSpace(string(headMsg)),
+	)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {

--- a/tests/tests/golden-files/test_issue_comment_integration.yml
+++ b/tests/tests/golden-files/test_issue_comment_integration.yml
@@ -6,6 +6,11 @@ output:
 - 'git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/integration.git'
 - 'git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/integration'
 - 'git.Run: /usr/bin/git fetch github pull/2725/merge:pr_2725_protected'
+- 'git.Run: /usr/bin/git rev-parse pr_2725_protected^2'
+- 'git.Run: /usr/bin/git log -1 --format=%B pr_2725_protected^2'
+- 'git.Run: /usr/bin/git checkout pr_2725_protected'
+- 'git.Run: /usr/bin/git -c user.email=mender-test-bot@northern.tech -c user.name=Mender
+  Test Runner commit --amend -m '
 - 'git.Run: /usr/bin/git push -f -o ci.skip --set-upstream gitlab pr_2725_protected'
 - 'info:Created branch: integration:pr_2725_protected'
 - 'gitlab.ProtectedBranch: path=Northern.tech/Mender/integration,options={"name":"pr_2725_protected","allow_force_push":false}'

--- a/tests/tests/golden-files/test_pull_request_opened_from_branch.yml
+++ b/tests/tests/golden-files/test_pull_request_opened_from_branch.yml
@@ -5,6 +5,11 @@ output:
 - 'git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/mender-docs.git'
 - 'git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/mender-docs'
 - 'git.Run: /usr/bin/git fetch github pull/1483/merge:pr_1483'
+- 'git.Run: /usr/bin/git rev-parse pr_1483^2'
+- 'git.Run: /usr/bin/git log -1 --format=%B pr_1483^2'
+- 'git.Run: /usr/bin/git checkout pr_1483'
+- 'git.Run: /usr/bin/git -c user.email=mender-test-bot@northern.tech -c user.name=Mender
+  Test Runner commit --amend -m '
 - 'git.Run: /usr/bin/git push -f -o ci.skip --set-upstream gitlab pr_1483'
 - 'info:Created branch: mender-docs:pr_1483'
 - 'gitlab.CreatePipeline: path=Northern.tech/Mender/mender-docs,options={"ref":"pr_1483","variables":[{"key":"CI_EXTERNAL_PULL_REQUEST_IID","value":"1483"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_REPOSITORY","value":"mendersoftware/mender-docs"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_REPOSITORY","value":"mendersoftware/mender-docs"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME","value":"QA-251-tests-mutual-tls"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA","value":"d87e5c741112a9a3def98f307723b5760a100271"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME","value":"master"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_SHA","value":"e312f4d62f66ba74e840afed5f267e5f897da20f"}]}'

--- a/tests/tests/golden-files/test_pull_request_opened_from_fork.yml
+++ b/tests/tests/golden-files/test_pull_request_opened_from_fork.yml
@@ -5,6 +5,11 @@ output:
 - 'git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/workflows.git'
 - 'git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/workflows'
 - 'git.Run: /usr/bin/git fetch github pull/140/merge:pr_140'
+- 'git.Run: /usr/bin/git rev-parse pr_140^2'
+- 'git.Run: /usr/bin/git log -1 --format=%B pr_140^2'
+- 'git.Run: /usr/bin/git checkout pr_140'
+- 'git.Run: /usr/bin/git -c user.email=mender-test-bot@northern.tech -c user.name=Mender
+  Test Runner commit --amend -m '
 - 'git.Run: /usr/bin/git push -f -o ci.skip --set-upstream gitlab pr_140'
 - 'info:Created branch: workflows:pr_140'
 - 'gitlab.CreatePipeline: path=Northern.tech/Mender/workflows,options={"ref":"pr_140","variables":[{"key":"CI_EXTERNAL_PULL_REQUEST_IID","value":"140"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_REPOSITORY","value":"tranchitella/workflows"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_REPOSITORY","value":"mendersoftware/workflows"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME","value":"men-4705"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA","value":"7b099b84cb50df18847027b0afa16820eab850d9"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME","value":"master"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_SHA","value":"70ab90b3932d3d008ebee56d6cfe4f3329d5ee7b"}]}'

--- a/tests/tests/golden-files/test_pull_request_opened_from_fork_to_mender_qa_by_outsider.yml
+++ b/tests/tests/golden-files/test_pull_request_opened_from_fork_to_mender_qa_by_outsider.yml
@@ -5,6 +5,11 @@ output:
 - 'git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/mender-qa.git'
 - 'git.Run: /usr/bin/git remote add gitlab git@gitlab.com:Northern.tech/Mender/mender-qa'
 - 'git.Run: /usr/bin/git fetch github pull/550/merge:pr_550'
+- 'git.Run: /usr/bin/git rev-parse pr_550^2'
+- 'git.Run: /usr/bin/git log -1 --format=%B pr_550^2'
+- 'git.Run: /usr/bin/git checkout pr_550'
+- 'git.Run: /usr/bin/git -c user.email=mender-test-bot@northern.tech -c user.name=Mender
+  Test Runner commit --amend -m '
 - 'git.Run: /usr/bin/git push -f -o ci.skip --set-upstream gitlab pr_550'
 - 'info:Created branch: mender-qa:pr_550'
 - 'github.IsOrganizationMember: org=mendersoftware,user=Junglebobo'


### PR DESCRIPTION
After switching to pull/NNN/merge refs two issues appeared:

1. GitLab displayed the auto-generated "Merge <sha>...." commit message

2. GitHub computes pull/NNN/merge asynchronously so the webhook can fire before the ref is updated added retry (up to 2 times, 5s apart)

Ticket: QA-1505