### PR TITLE
fix(pullreq_pipeline): remove hardcoded git identity from amend command

### DIFF
--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -194,8 +194,7 @@ func syncBranch(
 	}
 
 	gitcmd = git.Command(
-		"-c", "user.email=mender-test-bot@northern.tech",
-		"-c", "user.name=Mender Test Runner",
+		"-c", "commit.gpgsign=false",
 		"commit", "--amend", "-m", strings.TrimSpace(string(headMsg)),
 	)
 	gitcmd.Dir = tmpdir


### PR DESCRIPTION
The user.email and user.name -c flags override the git identity for the amend commit - it leads to sync issue  https://github.com/mendersoftware/integration-test-runner/pull/448#issuecomment-4343837109

Ticket: QA-1505