### PR TITLE
fix(pullreq_pipeline): start GitLab pipeline after manual sync command

### DIFF
--- a/pullreq_pipeline.go
+++ b/pullreq_pipeline.go
@@ -203,8 +203,7 @@ func syncBranch(
 		return fmt.Errorf("%v returned error: %s: %s", gitcmd.Args, out, err.Error())
 	}
 
-	// Push but not don't trigger CI (yet)
-	gitcmd = git.Command("push", "-f", "-o", "ci.skip", "--set-upstream", "gitlab", prBranchName)
+	gitcmd = git.Command("push", "-f", "--set-upstream", "gitlab", prBranchName)
 	gitcmd.Dir = tmpdir
 	out, err = gitcmd.CombinedOutput()
 	if err != nil {

--- a/tests/tests/golden-files/test_issue_comment_integration.yml
+++ b/tests/tests/golden-files/test_issue_comment_integration.yml
@@ -10,7 +10,7 @@ output:
 - 'git.Run: /usr/bin/git log -1 --format=%B pr_2725_protected^2'
 - 'git.Run: /usr/bin/git checkout pr_2725_protected'
 - 'git.Run: /usr/bin/git -c commit.gpgsign=false commit --amend -m '
-- 'git.Run: /usr/bin/git push -f -o ci.skip --set-upstream gitlab pr_2725_protected'
+- 'git.Run: /usr/bin/git push -f --set-upstream gitlab pr_2725_protected'
 - 'info:Created branch: integration:pr_2725_protected'
 - 'gitlab.ProtectedBranch: path=Northern.tech/Mender/integration,options={"name":"pr_2725_protected","allow_force_push":false}'
 - 'gitlab.ListProjectPipelines: path=Northern.tech/Mender/mender-qa,options={"status":"pending","username":"mender-test-bot"}'

--- a/tests/tests/golden-files/test_pull_request_opened_from_branch.yml
+++ b/tests/tests/golden-files/test_pull_request_opened_from_branch.yml
@@ -9,7 +9,7 @@ output:
 - 'git.Run: /usr/bin/git log -1 --format=%B pr_1483^2'
 - 'git.Run: /usr/bin/git checkout pr_1483'
 - 'git.Run: /usr/bin/git -c commit.gpgsign=false commit --amend -m '
-- 'git.Run: /usr/bin/git push -f -o ci.skip --set-upstream gitlab pr_1483'
+- 'git.Run: /usr/bin/git push -f --set-upstream gitlab pr_1483'
 - 'info:Created branch: mender-docs:pr_1483'
 - 'gitlab.CreatePipeline: path=Northern.tech/Mender/mender-docs,options={"ref":"pr_1483","variables":[{"key":"CI_EXTERNAL_PULL_REQUEST_IID","value":"1483"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_REPOSITORY","value":"mendersoftware/mender-docs"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_REPOSITORY","value":"mendersoftware/mender-docs"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME","value":"QA-251-tests-mutual-tls"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA","value":"d87e5c741112a9a3def98f307723b5760a100271"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME","value":"master"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_SHA","value":"e312f4d62f66ba74e840afed5f267e5f897da20f"}]}'
 - 'debug:started pipeline for PR: '

--- a/tests/tests/golden-files/test_pull_request_opened_from_fork.yml
+++ b/tests/tests/golden-files/test_pull_request_opened_from_fork.yml
@@ -9,7 +9,7 @@ output:
 - 'git.Run: /usr/bin/git log -1 --format=%B pr_140^2'
 - 'git.Run: /usr/bin/git checkout pr_140'
 - 'git.Run: /usr/bin/git -c commit.gpgsign=false commit --amend -m '
-- 'git.Run: /usr/bin/git push -f -o ci.skip --set-upstream gitlab pr_140'
+- 'git.Run: /usr/bin/git push -f --set-upstream gitlab pr_140'
 - 'info:Created branch: workflows:pr_140'
 - 'gitlab.CreatePipeline: path=Northern.tech/Mender/workflows,options={"ref":"pr_140","variables":[{"key":"CI_EXTERNAL_PULL_REQUEST_IID","value":"140"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_REPOSITORY","value":"tranchitella/workflows"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_REPOSITORY","value":"mendersoftware/workflows"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_NAME","value":"men-4705"},{"key":"CI_EXTERNAL_PULL_REQUEST_SOURCE_BRANCH_SHA","value":"7b099b84cb50df18847027b0afa16820eab850d9"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_NAME","value":"master"},{"key":"CI_EXTERNAL_PULL_REQUEST_TARGET_BRANCH_SHA","value":"70ab90b3932d3d008ebee56d6cfe4f3329d5ee7b"}]}'
 - 'debug:started pipeline for PR: '

--- a/tests/tests/golden-files/test_pull_request_opened_from_fork_to_mender_qa_by_outsider.yml
+++ b/tests/tests/golden-files/test_pull_request_opened_from_fork_to_mender_qa_by_outsider.yml
@@ -9,7 +9,7 @@ output:
 - 'git.Run: /usr/bin/git log -1 --format=%B pr_550^2'
 - 'git.Run: /usr/bin/git checkout pr_550'
 - 'git.Run: /usr/bin/git -c commit.gpgsign=false commit --amend -m '
-- 'git.Run: /usr/bin/git push -f -o ci.skip --set-upstream gitlab pr_550'
+- 'git.Run: /usr/bin/git push -f --set-upstream gitlab pr_550'
 - 'info:Created branch: mender-qa:pr_550'
 - 'github.IsOrganizationMember: org=mendersoftware,user=Junglebobo'
 - warning:Junglebobo is making a pullrequest, but he/she is not a member of our 


### PR DESCRIPTION
The @mender-test-bot sync comment handler only synced the branch to GitLab but never called startPRPipeline leaving the pipeline in skipped state (ci.skip was added when switching to pull/NNN/merge)

sett the organization field on the synthetic PullRequestEvent so that getRemoteURLGitLab resolves the correct GitLab group instead of failing with an unrecognized empty-string organization

Ticket: QA-1505