### PR TITLE
chore(fix): fix silent error reporting in syncPRBranch

### DIFF
--- a/main_comment.go
+++ b/main_comment.go
@@ -304,9 +304,10 @@ func syncPRBranch(
 	conf *config,
 ) {
 	prEvent := &github.PullRequestEvent{
-		Repo:        comment.GetRepo(),
-		Number:      github.Int(pr.GetNumber()),
-		PullRequest: pr,
+		Repo:         comment.GetRepo(),
+		Number:       github.Int(pr.GetNumber()),
+		PullRequest:  pr,
+		Organization: &github.Organization{Login: github.String(conf.githubOrganization)},
 	}
 	if _, err := syncPullRequestBranch(log, prEvent, conf); err != nil {
 		mainErrMsg := "There was an error syncing branches"


### PR DESCRIPTION
The prEvent constructed from an IssueCommentEvent was missing the org field, causing postGitHubMessage to call the GitHub API with an empty org the API call failed silently, so manual @mender-test-bot sync commands produced no visible feedback.