### PR TITLE
feat(integration-test-runner): add skip pipeline command to mender-test-bot

### DIFF
--- a/client/github/client.go
+++ b/client/github/client.go
@@ -75,6 +75,12 @@ type Client interface {
 		owner, repo, path string,
 		opts *github.RepositoryContentGetOptions,
 	) (*github.RepositoryContent, []*github.RepositoryContent, error)
+
+	CreateStatus(
+		ctx context.Context,
+		owner, repo, sha string,
+		status *github.RepoStatus,
+	) error
 }
 
 type gitHubClient struct {
@@ -243,4 +249,21 @@ func (c *gitHubClient) GetContents(
 		opts,
 	)
 	return fileContent, dirContents, err
+}
+
+func (c *gitHubClient) CreateStatus(
+	ctx context.Context,
+	owner, repo, sha string,
+	status *github.RepoStatus,
+) error {
+	if c.dryRunMode {
+		statusJSON, _ := json.Marshal(status)
+		msg := fmt.Sprintf("github.CreateStatus: owner=%s,repo=%s,sha=%s,status=%s",
+			owner, repo, sha, string(statusJSON),
+		)
+		logger.GetRequestLogger().Push(msg)
+		return nil
+	}
+	_, _, err := c.client.Repositories.CreateStatus(ctx, owner, repo, sha, status)
+	return err
 }

--- a/client/github/mocks/Client.go
+++ b/client/github/mocks/Client.go
@@ -98,6 +98,20 @@ func (_m *Client) GetContents(ctx context.Context, owner string, repo string, pa
 	return r0, r1, r2
 }
 
+// CreateStatus provides a mock function with given fields: ctx, owner, repo, sha, status
+func (_m *Client) CreateStatus(ctx context.Context, owner string, repo string, sha string, status *v28github.RepoStatus) error {
+	ret := _m.Called(ctx, owner, repo, sha, status)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, *v28github.RepoStatus) error); ok {
+		r0 = rf(ctx, owner, repo, sha, status)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DeleteComment provides a mock function with given fields: ctx, org, repo, commentID
 func (_m *Client) DeleteComment(ctx context.Context, org string, repo string, commentID int64) error {
 	ret := _m.Called(ctx, org, repo, commentID)

--- a/main.go
+++ b/main.go
@@ -33,8 +33,9 @@ type config struct {
 	integrationDirectory   string
 	isProcessPushEvents    bool
 	isProcessPREvents      bool
-	isProcessCommentEvents bool
-	reposSyncList          []string
+	isProcessCommentEvents  bool
+	reposSyncList           []string
+	pipelineStatusContexts  []string
 }
 
 type buildOptions struct {
@@ -118,6 +119,7 @@ const (
 	commandSyncRepos                = "sync"
 	commandPrintPRStats             = "print fast pr stats"
 	commandPrintFullPRStats         = "print full pr stats"
+	commandSkipPipeline             = "skip pipeline"
 )
 
 func getConfig() (*config, error) {
@@ -167,6 +169,12 @@ func getConfig() (*config, error) {
 		reposSyncList = strings.Split(reposSyncListRaw, ",")
 	}
 
+	var pipelineStatusContexts []string
+	pipelineStatusContextsRaw, found := os.LookupEnv("PIPELINE_STATUS_CONTEXTS")
+	if found {
+		pipelineStatusContexts = strings.Split(pipelineStatusContextsRaw, ",")
+	}
+
 	switch {
 	case githubSecret == "" && !dryRunMode:
 		return &config{}, fmt.Errorf("set GITHUB_SECRET")
@@ -189,9 +197,10 @@ func getConfig() (*config, error) {
 		gitlabBaseURL:          gitlabBaseURL,
 		integrationDirectory:   integrationDirectory,
 		isProcessPushEvents:    isProcessPushEvents,
-		isProcessPREvents:      isProcessPREvents,
-		isProcessCommentEvents: isProcessCommentEvents,
-		reposSyncList:          reposSyncList,
+		isProcessPREvents:       isProcessPREvents,
+		isProcessCommentEvents:  isProcessCommentEvents,
+		reposSyncList:           reposSyncList,
+		pipelineStatusContexts:  pipelineStatusContexts,
 	}, nil
 }
 

--- a/main_comment.go
+++ b/main_comment.go
@@ -183,6 +183,8 @@ func processGitHubComment(
 	case strings.Contains(commentBody, commandPrintFullPRStats) ||
 		strings.Contains(commentBody, commandPrintPRStats):
 		handlePRStatsCommand(ctx, comment, pr, githubClient, conf, log, commentBody)
+	case strings.Contains(commentBody, commandSkipPipeline):
+		skipPipelines(ctx, comment, pr, githubClient, conf, log)
 	default:
 		log.Warnf("no command found: %s", commentBody)
 		return nil
@@ -498,4 +500,43 @@ func parseBuildOptions(commentBody string) (*BuildOptions, error) {
 	}
 
 	return buildOptions, err
+}
+
+func skipPipelines(
+	ctx *gin.Context,
+	comment *github.IssueCommentEvent,
+	pr *github.PullRequest,
+	githubClient clientgithub.Client,
+	conf *config,
+	log *logrus.Entry,
+) {
+	sha := pr.GetHead().GetSHA()
+	repo := comment.GetRepo().GetName()
+	org := conf.githubOrganization
+
+	successState := "success"
+	description := "Skipped by " + comment.GetSender().GetLogin()
+	for _, statusContext := range conf.pipelineStatusContexts {
+		sc := statusContext
+		status := &github.RepoStatus{
+			State:       &successState,
+			Description: &description,
+			Context:     &sc,
+		}
+		if err := githubClient.CreateStatus(ctx, org, repo, sha, status); err != nil {
+			log.Errorf("skipPipelines: failed to set status for context %s: %s", sc, err.Error())
+		}
+	}
+
+	msg := "Pipeline skipped by @" + comment.GetSender().GetLogin()
+	err := githubClient.CreateComment(
+		ctx,
+		org,
+		repo,
+		pr.GetNumber(),
+		&github.IssueComment{Body: &msg},
+	)
+	if err != nil {
+		log.Errorf("skipPipelines: failed to comment on PR: %s", err.Error())
+	}
 }

--- a/main_comment_test.go
+++ b/main_comment_test.go
@@ -33,8 +33,10 @@ func TestProcessGitHubWebhook(t *testing.T) {
 		pullRequest          *github.PullRequest
 		pullRequestErr       error
 
-		err           error
-		createComment bool
+		err                    error
+		createComment          bool
+		createStatus           bool
+		pipelineStatusContexts []string
 	}{
 		"comment updated, ignore": {
 			webhookType: "issue_comment",
@@ -410,6 +412,46 @@ func TestProcessGitHubWebhook(t *testing.T) {
 			},
 			createComment: true,
 		},
+		"comment from organization user, skip pipeline": {
+			webhookType: "issue_comment",
+			webhookEvent: &github.IssueCommentEvent{
+				Action: github.String("created"),
+				Comment: &github.IssueComment{
+					Body: github.String("@" + githubBotName + " skip pipeline"),
+				},
+				Issue: &github.Issue{
+					PullRequestLinks: &github.PullRequestLinks{
+						URL: github.String("https://api.github.com/repos/mendersoftware/integration-test-runner/pulls/78"),
+					},
+				},
+				Repo: &github.Repository{
+					Name: github.String("integration-test-runner"),
+					Owner: &github.User{
+						Login: github.String(gitHubOrg),
+					},
+				},
+				Sender: &github.User{
+					Login: github.String("member"),
+				},
+			},
+
+			isCommentEventProcessingEnabled: true,
+			isOrganizationMember:            github.Bool(true),
+
+			repo:     "integration-test-runner",
+			prNumber: 78,
+
+			pullRequest: &github.PullRequest{
+				Number: github.Int(78),
+				Head: &github.PullRequestBranch{
+					SHA: github.String("abc123"),
+				},
+			},
+
+			pipelineStatusContexts: []string{"ci/mender-qa", "ci/integration"},
+			createStatus:           true,
+			createComment:          true,
+		},
 	}
 
 	for name, tc := range testCases {
@@ -467,6 +509,18 @@ func TestProcessGitHubWebhook(t *testing.T) {
 				).Return(nil)
 			}
 
+			if tc.createStatus {
+				mclient.On("CreateStatus",
+					mock.MatchedBy(func(ctx context.Context) bool {
+						return true
+					}),
+					gitHubOrg,
+					tc.repo,
+					mock.AnythingOfType("string"),
+					mock.AnythingOfType("*github.RepoStatus"),
+				).Return(nil).Times(len(tc.pipelineStatusContexts))
+			}
+
 			// Mock ListPullRequests for PR stats command
 			if tc.webhookType == "issue_comment" {
 				event := tc.webhookEvent.(*github.IssueCommentEvent)
@@ -483,6 +537,7 @@ func TestProcessGitHubWebhook(t *testing.T) {
 				isProcessCommentEvents: tc.isCommentEventProcessingEnabled,
 				isProcessPREvents:      tc.isPREventsProcessingEnabled,
 				isProcessPushEvents:    tc.isCommentEventsProcessingEnabled,
+				pipelineStatusContexts: tc.pipelineStatusContexts,
 			}
 
 			ctx := &gin.Context{}


### PR DESCRIPTION
## Summary

- Adds `@mender-test-bot skip pipeline` comment command
- Posts a GitHub success commit status for each context in `PIPELINE_STATUS_CONTEXTS` (comma-separated env var)
- Posts a confirmation comment on the PR

Ticket: QA-1560