### PR TITLE
chore: update yocto variables

### DIFF
--- a/menderqa_pipeline.go
+++ b/menderqa_pipeline.go
@@ -334,8 +334,8 @@ func getMenderClientBuildParameters(
 		})
 
 	// Yocto params: same behavior as the legacy path for non-master builds
-	pokyBranch := LatestStableYoctoBranch
-	metaMenderBranch := pokyBranch
+	yoctoBranch := LatestStableYoctoBranch
+	metaMenderBranch := yoctoBranch
 	if prOverride, exists := buildOptions.PullRequests["meta-mender"]; exists {
 		metaMenderBranch = prOverride
 	}
@@ -345,15 +345,15 @@ func getMenderClientBuildParameters(
 			Key:   &metaMenderBranchKey,
 			Value: &metaMenderBranch,
 		})
-	pokyBranchKey := repoToBuildParameter("poky")
+	yoctoBranchKey := repoToBuildParameter("yocto")
 	buildParameters = append(buildParameters,
-		&gitlab.PipelineVariableOptions{Key: &pokyBranchKey, Value: &pokyBranch})
+		&gitlab.PipelineVariableOptions{Key: &yoctoBranchKey, Value: &yoctoBranch})
 	metaOEKey := repoToBuildParameter("meta-openembedded")
 	buildParameters = append(buildParameters,
-		&gitlab.PipelineVariableOptions{Key: &metaOEKey, Value: &pokyBranch})
+		&gitlab.PipelineVariableOptions{Key: &metaOEKey, Value: &yoctoBranch})
 	metaRPIKey := repoToBuildParameter("meta-raspberrypi")
 	buildParameters = append(buildParameters,
-		&gitlab.PipelineVariableOptions{Key: &metaRPIKey, Value: &pokyBranch})
+		&gitlab.PipelineVariableOptions{Key: &metaRPIKey, Value: &yoctoBranch})
 
 	// CI build parameters
 	runIntegrationTests := "true"
@@ -460,19 +460,19 @@ func getMenderClientBuildParametersLegacy(
 		}
 	}
 
-	// Set poky (& friends) and meta-mender revisions:
+	// Set Yocto (& friends) and meta-mender revisions:
 	// - If building a master PR, leave everything at defaults, which generally means
-	//   meta-mender/master and poky/LatestStableYoctoBranch.
-	// - If building meta-mender @ non-master, set poky branches to its baseBranch.
-	// - If building any other repo @ non-master, set both meta-mender and poky to
+	//   meta-mender/master and YOCTO_REV/LatestStableYoctoBranch.
+	// - If building meta-mender @ non-master, set Yocto branches to its baseBranch.
+	// - If building any other repo @ non-master, set both meta-mender and Yocto to
 	//   LatestStableYoctoBranch.
 	if build.baseBranch != "master" {
-		var pokyBranch string
+		var yoctoBranch string
 		if build.repo == "meta-mender" {
-			pokyBranch = build.baseBranch
+			yoctoBranch = build.baseBranch
 		} else {
-			pokyBranch = LatestStableYoctoBranch
-			metaMenderBranch := pokyBranch
+			yoctoBranch = LatestStableYoctoBranch
+			metaMenderBranch := yoctoBranch
 			metaMenderBranchKey := repoToBuildParameter("meta-mender")
 			buildParameters = append(
 				buildParameters,
@@ -482,25 +482,25 @@ func getMenderClientBuildParametersLegacy(
 				},
 			)
 		}
-		pokyBranchKey := repoToBuildParameter("poky")
+		yoctoBranchKey := repoToBuildParameter("yocto")
 		buildParameters = append(
 			buildParameters,
-			&gitlab.PipelineVariableOptions{Key: &pokyBranchKey, Value: &pokyBranch},
+			&gitlab.PipelineVariableOptions{Key: &yoctoBranchKey, Value: &yoctoBranch},
 		)
-		metaOEPokyBranchKey := repoToBuildParameter("meta-openembedded")
+		metaOEYoctoBranchKey := repoToBuildParameter("meta-openembedded")
 		buildParameters = append(
 			buildParameters,
 			&gitlab.PipelineVariableOptions{
-				Key:   &metaOEPokyBranchKey,
-				Value: &pokyBranch,
+				Key:   &metaOEYoctoBranchKey,
+				Value: &yoctoBranch,
 			},
 		)
-		metaRPIPokyBranchKey := repoToBuildParameter("meta-raspberrypi")
+		metaRPIYoctoBranchKey := repoToBuildParameter("meta-raspberrypi")
 		buildParameters = append(
 			buildParameters,
 			&gitlab.PipelineVariableOptions{
-				Key:   &metaRPIPokyBranchKey,
-				Value: &pokyBranch,
+				Key:   &metaRPIYoctoBranchKey,
+				Value: &yoctoBranch,
 			},
 		)
 	}

--- a/tests/tests/golden-files/test_issue_comment_minor_series.yml
+++ b/tests/tests/golden-files/test_issue_comment_minor_series.yml
@@ -52,12 +52,11 @@ output:
   INVENTORY_ENTERPRISE_REV:4.0.x, INVENTORY_REV:4.0.x, MENDER_ARTIFACT_REV:3.6.x,
   MENDER_CLI_REV:1.7.x, MENDER_CONNECT_REV:1.2.x, MENDER_REV:pull/865/head, META_MENDER_REV:scarthgap,
   META_OPENEMBEDDED_REV:scarthgap, META_RASPBERRYPI_REV:scarthgap, MONITOR_CLIENT_REV:1.0.x,
-  MTLS_AMBASSADOR_REV:1.0.x, POKY_REV:scarthgap, RUN_INTEGRATION_TESTS:true, TENANTADM_REV:3.3.x,
-  TEST_QEMUX86_64_BIOS_GRUB:true, TEST_QEMUX86_64_BIOS_GRUB_GPT:true, TEST_QEMUX86_64_UEFI_GRUB:true,
-  TEST_VEXPRESS_QEMU:true, TEST_VEXPRESS_QEMU_FLASH:true, TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB:true,
-  USERADM_ENTERPRISE_REV:1.16.x, USERADM_REV:1.16.x, WORKFLOWS_ENTERPRISE_REV:2.1.x,
-  WORKFLOWS_REV:2.1.x, '
-- 'gitlab.CreatePipeline: path=Northern.tech/Mender/mender-qa,options={"ref":"master","variables":[{"key":"AUDITLOGS_REV","value":"2.0.x"},{"key":"BUILD_BEAGLEBONEBLACK","value":"true"},{"key":"BUILD_CLIENT","value":"true"},{"key":"BUILD_QEMUX86_64_BIOS_GRUB","value":"true"},{"key":"BUILD_QEMUX86_64_BIOS_GRUB_GPT","value":"true"},{"key":"BUILD_QEMUX86_64_UEFI_GRUB","value":"true"},{"key":"BUILD_VEXPRESS_QEMU","value":"true"},{"key":"BUILD_VEXPRESS_QEMU_FLASH","value":"true"},{"key":"BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":"true"},{"key":"CREATE_ARTIFACT_WORKER_REV","value":"1.0.x"},{"key":"DEPLOYMENTS_ENTERPRISE_REV","value":"4.0.x"},{"key":"DEPLOYMENTS_REV","value":"4.0.x"},{"key":"DEVICEAUTH_REV","value":"3.1.x"},{"key":"DEVICECONFIG_REV","value":"1.1.x"},{"key":"DEVICECONNECT_REV","value":"1.2.x"},{"key":"DEVICEMONITOR_REV","value":"1.0.x"},{"key":"GUI_REV","value":"3.1.x"},{"key":"INTEGRATION_REV","value":"3.1.x"},{"key":"INVENTORY_ENTERPRISE_REV","value":"4.0.x"},{"key":"INVENTORY_REV","value":"4.0.x"},{"key":"MENDER_ARTIFACT_REV","value":"3.6.x"},{"key":"MENDER_CLI_REV","value":"1.7.x"},{"key":"MENDER_CONNECT_REV","value":"1.2.x"},{"key":"MENDER_REV","value":"pull/865/head"},{"key":"META_MENDER_REV","value":"scarthgap"},{"key":"META_OPENEMBEDDED_REV","value":"scarthgap"},{"key":"META_RASPBERRYPI_REV","value":"scarthgap"},{"key":"MONITOR_CLIENT_REV","value":"1.0.x"},{"key":"MTLS_AMBASSADOR_REV","value":"1.0.x"},{"key":"POKY_REV","value":"scarthgap"},{"key":"RUN_INTEGRATION_TESTS","value":"true"},{"key":"TENANTADM_REV","value":"3.3.x"},{"key":"TEST_QEMUX86_64_BIOS_GRUB","value":"true"},{"key":"TEST_QEMUX86_64_BIOS_GRUB_GPT","value":"true"},{"key":"TEST_QEMUX86_64_UEFI_GRUB","value":"true"},{"key":"TEST_VEXPRESS_QEMU","value":"true"},{"key":"TEST_VEXPRESS_QEMU_FLASH","value":"true"},{"key":"TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":"true"},{"key":"USERADM_ENTERPRISE_REV","value":"1.16.x"},{"key":"USERADM_REV","value":"1.16.x"},{"key":"WORKFLOWS_ENTERPRISE_REV","value":"2.1.x"},{"key":"WORKFLOWS_REV","value":"2.1.x"}]}'
+  MTLS_AMBASSADOR_REV:1.0.x, RUN_INTEGRATION_TESTS:true, TENANTADM_REV:3.3.x, TEST_QEMUX86_64_BIOS_GRUB:true,
+  TEST_QEMUX86_64_BIOS_GRUB_GPT:true, TEST_QEMUX86_64_UEFI_GRUB:true, TEST_VEXPRESS_QEMU:true,
+  TEST_VEXPRESS_QEMU_FLASH:true, TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB:true, USERADM_ENTERPRISE_REV:1.16.x,
+  USERADM_REV:1.16.x, WORKFLOWS_ENTERPRISE_REV:2.1.x, WORKFLOWS_REV:2.1.x, YOCTO_REV:scarthgap, '
+- 'gitlab.CreatePipeline: path=Northern.tech/Mender/mender-qa,options={"ref":"master","variables":[{"key":"AUDITLOGS_REV","value":"2.0.x"},{"key":"BUILD_BEAGLEBONEBLACK","value":"true"},{"key":"BUILD_CLIENT","value":"true"},{"key":"BUILD_QEMUX86_64_BIOS_GRUB","value":"true"},{"key":"BUILD_QEMUX86_64_BIOS_GRUB_GPT","value":"true"},{"key":"BUILD_QEMUX86_64_UEFI_GRUB","value":"true"},{"key":"BUILD_VEXPRESS_QEMU","value":"true"},{"key":"BUILD_VEXPRESS_QEMU_FLASH","value":"true"},{"key":"BUILD_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":"true"},{"key":"CREATE_ARTIFACT_WORKER_REV","value":"1.0.x"},{"key":"DEPLOYMENTS_ENTERPRISE_REV","value":"4.0.x"},{"key":"DEPLOYMENTS_REV","value":"4.0.x"},{"key":"DEVICEAUTH_REV","value":"3.1.x"},{"key":"DEVICECONFIG_REV","value":"1.1.x"},{"key":"DEVICECONNECT_REV","value":"1.2.x"},{"key":"DEVICEMONITOR_REV","value":"1.0.x"},{"key":"GUI_REV","value":"3.1.x"},{"key":"INTEGRATION_REV","value":"3.1.x"},{"key":"INVENTORY_ENTERPRISE_REV","value":"4.0.x"},{"key":"INVENTORY_REV","value":"4.0.x"},{"key":"MENDER_ARTIFACT_REV","value":"3.6.x"},{"key":"MENDER_CLI_REV","value":"1.7.x"},{"key":"MENDER_CONNECT_REV","value":"1.2.x"},{"key":"MENDER_REV","value":"pull/865/head"},{"key":"META_MENDER_REV","value":"scarthgap"},{"key":"META_OPENEMBEDDED_REV","value":"scarthgap"},{"key":"META_RASPBERRYPI_REV","value":"scarthgap"},{"key":"MONITOR_CLIENT_REV","value":"1.0.x"},{"key":"MTLS_AMBASSADOR_REV","value":"1.0.x"},{"key":"RUN_INTEGRATION_TESTS","value":"true"},{"key":"TENANTADM_REV","value":"3.3.x"},{"key":"TEST_QEMUX86_64_BIOS_GRUB","value":"true"},{"key":"TEST_QEMUX86_64_BIOS_GRUB_GPT","value":"true"},{"key":"TEST_QEMUX86_64_UEFI_GRUB","value":"true"},{"key":"TEST_VEXPRESS_QEMU","value":"true"},{"key":"TEST_VEXPRESS_QEMU_FLASH","value":"true"},{"key":"TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB","value":"true"},{"key":"USERADM_ENTERPRISE_REV","value":"1.16.x"},{"key":"USERADM_REV","value":"1.16.x"},{"key":"WORKFLOWS_ENTERPRISE_REV","value":"2.1.x"},{"key":"WORKFLOWS_REV","value":"2.1.x"},{"key":"YOCTO_REV","value":"scarthgap"}]}'
 - 'info:Created pipeline: '
 - 'github.CreateComment: org=mendersoftware,repo=mender,number=865,comment={"body":"\nHello
   :smiley_cat: I created a pipeline for you here: [Pipeline-0]()\n\n\u003cdetails\u003e\n    \u003csummary\u003eBuild
@@ -73,10 +72,9 @@ output:
   INVENTORY_REV | 4.0.x |\n| MENDER_ARTIFACT_REV | 3.6.x |\n| MENDER_CLI_REV | 1.7.x
   |\n| MENDER_CONNECT_REV | 1.2.x |\n| MENDER_REV | pull/865/head |\n| META_MENDER_REV
   | scarthgap |\n| META_OPENEMBEDDED_REV | scarthgap |\n| META_RASPBERRYPI_REV | scarthgap
-  |\n| MONITOR_CLIENT_REV | 1.0.x |\n| MTLS_AMBASSADOR_REV | 1.0.x |\n| POKY_REV |
-  scarthgap |\n| RUN_INTEGRATION_TESTS | true |\n| TENANTADM_REV | 3.3.x |\n| TEST_QEMUX86_64_BIOS_GRUB
-  | true |\n| TEST_QEMUX86_64_BIOS_GRUB_GPT | true |\n| TEST_QEMUX86_64_UEFI_GRUB
-  | true |\n| TEST_VEXPRESS_QEMU | true |\n| TEST_VEXPRESS_QEMU_FLASH | true |\n|
-  TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB | true |\n| USERADM_ENTERPRISE_REV | 1.16.x |\n|
-  USERADM_REV | 1.16.x |\n| WORKFLOWS_ENTERPRISE_REV | 2.1.x |\n| WORKFLOWS_REV |
-  2.1.x |\n\n\n \u003c/p\u003e\u003c/details\u003e\n"}'
+  |\n| MONITOR_CLIENT_REV | 1.0.x |\n| MTLS_AMBASSADOR_REV | 1.0.x |\n| RUN_INTEGRATION_TESTS
+  | true |\n| TENANTADM_REV | 3.3.x |\n| TEST_QEMUX86_64_BIOS_GRUB | true |\n| TEST_QEMUX86_64_BIOS_GRUB_GPT
+  | true |\n| TEST_QEMUX86_64_UEFI_GRUB | true |\n| TEST_VEXPRESS_QEMU | true |\n|
+  TEST_VEXPRESS_QEMU_FLASH | true |\n| TEST_VEXPRESS_QEMU_UBOOT_UEFI_GRUB | true |\n|
+  USERADM_ENTERPRISE_REV | 1.16.x |\n| USERADM_REV | 1.16.x |\n| WORKFLOWS_ENTERPRISE_REV
+  | 2.1.x |\n| WORKFLOWS_REV | 2.1.x |\n| YOCTO_REV | scarthgap |\n\n\n \u003c/p\u003e\u003c/details\u003e\n"}'


### PR DESCRIPTION
Makes mender-test-bot start the mender-qa pipeline with the correct revisions after we've moved away from the poky repo.

Ticket: QA-1632