### PR TITLE
fix(main_comment): handle protected branch propagation delay when syn…

### DIFF
--- a/main_comment.go
+++ b/main_comment.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/gin-gonic/gin"
@@ -190,6 +191,18 @@ func processGitHubComment(
 	return nil
 }
 
+func unprotectBranch(client clientgitlab.Client, branchName string, pipelinePath string) error {
+	response, err := client.UnprotectRepositoryBranches(pipelinePath, branchName, nil)
+	if err != nil {
+		// branch may not be protected yet
+		if response != nil && response.StatusCode == 404 {
+			return nil
+		}
+		return fmt.Errorf("failed to unprotect branch %s: %s", branchName, err.Error())
+	}
+	return nil
+}
+
 func protectBranch(
 	client clientgitlab.Client, branchName string, pipelinePath string,
 ) error {
@@ -200,10 +213,6 @@ func protectBranch(
 	}
 	_, err := client.ProtectRepositoryBranches(pipelinePath, opt)
 	if err != nil {
-		// 409 means the branch is already protected with allow-force-push; continue
-		if errResp, ok := err.(*gitlab.ErrorResponse); ok && errResp.HasStatusCode(409) {
-			return nil
-		}
 		return fmt.Errorf("%v returned error: %s", err, err.Error())
 	}
 	return nil
@@ -212,6 +221,15 @@ func protectBranch(
 type branchSyncer func(
 	branchName string, log *logrus.Entry, pr *github.PullRequestEvent, conf *config,
 ) error
+
+const (
+	maxSyncRetries = 3
+	syncRetryDelay = 3 * time.Second
+)
+
+func isProtectedBranchError(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "protected branch")
+}
 
 // syncProtectedBranchWithClient is the testable core of syncProtectedBranch.
 // The branch is kept permanently protected with allow-force-push so that
@@ -228,15 +246,36 @@ func syncProtectedBranchWithClient(
 ) (string, error) {
 	prBranchName := "pr_" + strconv.Itoa(pr.GetNumber()) + "_protected"
 
-	// Protect with allow-force-push so the pipeline triggered by the push
-	// sees the branch as protected and receives CI secrets. 409 is ignored
-	// since the branch may already be protected from a previous run.
+	// Unprotect first (idempotent — 404 ignored) then re-protect with
+	// allow-force-push so the pipeline sees the branch as protected and
+	// receives CI secrets. Unprotecting first ensures we don't silently
+	// skip re-protection when the branch was previously protected without
+	// allow-force-push.
+	if err := unprotectBranch(client, prBranchName, pipelinePath); err != nil {
+		return "", fmt.Errorf("failed to unprotect branch before sync: %s", err.Error())
+	}
 	if err := protectBranch(client, prBranchName, pipelinePath); err != nil {
 		return "", fmt.Errorf("failed to protect branch before sync: %s", err.Error())
 	}
 
-	if err := syncer(prBranchName, log, pr, conf); err != nil {
-		return "", fmt.Errorf("There was an error syncing branches: %s", err.Error())
+	// Retry the push: GitLab may take a moment to propagate the updated
+	// protection rule, causing the first push attempt to be rejected.
+	var lastErr error
+	for attempt := 1; attempt <= maxSyncRetries; attempt++ {
+		lastErr = syncer(prBranchName, log, pr, conf)
+		if lastErr == nil || !isProtectedBranchError(lastErr) {
+			break
+		}
+		if attempt < maxSyncRetries {
+			log.Warnf(
+				"push to %s rejected due to branch protection (attempt %d/%d), retrying in %s",
+				prBranchName, attempt, maxSyncRetries, syncRetryDelay,
+			)
+			time.Sleep(syncRetryDelay)
+		}
+	}
+	if lastErr != nil {
+		return "", fmt.Errorf("There was an error syncing branches: %s", lastErr.Error())
 	}
 
 	return prBranchName, nil

--- a/main_comment_test.go
+++ b/main_comment_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"errors"
-	"net/http"
 	"strings"
 	"testing"
 
@@ -671,6 +670,10 @@ func TestSyncProtectedBranchWithClientProtectsBeforePush(t *testing.T) {
 
 	gitlabClient := mock_gitlab.NewClient(t)
 
+	gitlabClient.On("UnprotectRepositoryBranches", pipelinePath, branchName, mock.Anything).
+		Run(func(args mock.Arguments) { callOrder = append(callOrder, "unprotect") }).
+		Return(nil, nil).Once()
+
 	gitlabClient.On("ProtectRepositoryBranches", pipelinePath, mock.MatchedBy(func(opts *gitlab.ProtectRepositoryBranchesOptions) bool {
 		return opts.AllowForcePush != nil && *opts.AllowForcePush == true
 	})).Run(func(args mock.Arguments) {
@@ -687,19 +690,17 @@ func TestSyncProtectedBranchWithClientProtectsBeforePush(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, branchName, name)
-	assert.Equal(t, []string{"protect:allow-force", "push"}, callOrder)
+	assert.Equal(t, []string{"unprotect", "protect:allow-force", "push"}, callOrder)
 }
 
-func TestSyncProtectedBranchWithClientAlreadyProtected409(t *testing.T) {
+// TestSyncProtectedBranchWithClientPushRetry verifies that a "protected branch"
+// push error is retried, handling GitLab's propagation delay after re-protection.
+func TestSyncProtectedBranchWithClientPushRetry(t *testing.T) {
 	pr := &github.PullRequestEvent{
 		Number: github.Int(42),
-		Repo: &github.Repository{
-			Name: github.String("mender"),
-		},
+		Repo:   &github.Repository{Name: github.String("mender")},
 		PullRequest: &github.PullRequest{
-			Head: &github.PullRequestBranch{
-				SHA: github.String("abc123"),
-			},
+			Head: &github.PullRequestBranch{SHA: github.String("abc123")},
 		},
 		Organization: &github.Organization{Login: github.String("mendersoftware")},
 	}
@@ -707,15 +708,17 @@ func TestSyncProtectedBranchWithClientAlreadyProtected409(t *testing.T) {
 	pipelinePath := "Northern.tech/Mender/mender"
 
 	gitlabClient := mock_gitlab.NewClient(t)
-
+	gitlabClient.On("UnprotectRepositoryBranches", pipelinePath, "pr_42_protected", mock.Anything).
+		Return(nil, nil).Once()
 	gitlabClient.On("ProtectRepositoryBranches", pipelinePath, mock.Anything).
-		Return(nil, &gitlab.ErrorResponse{
-			Response: &http.Response{StatusCode: 409},
-		}).Once()
+		Return(&gitlab.ProtectedBranch{}, nil).Once()
 
-	pushed := false
+	attempts := 0
 	syncer := func(branchName string, log *logrus.Entry, pr *github.PullRequestEvent, conf *config) error {
-		pushed = true
+		attempts++
+		if attempts < 2 {
+			return errors.New("push failed: protected branch")
+		}
 		return nil
 	}
 
@@ -723,7 +726,7 @@ func TestSyncProtectedBranchWithClientAlreadyProtected409(t *testing.T) {
 	_, err := syncProtectedBranchWithClient(log, pr, conf, pipelinePath, gitlabClient, syncer)
 
 	assert.NoError(t, err)
-	assert.True(t, pushed, "syncer should be called even when protect returns 409")
+	assert.Equal(t, 2, attempts, "should retry once after protected branch error")
 }
 
 func TestSyncProtectedBranchWithClientPushFailurePropagated(t *testing.T) {
@@ -744,6 +747,8 @@ func TestSyncProtectedBranchWithClientPushFailurePropagated(t *testing.T) {
 
 	gitlabClient := mock_gitlab.NewClient(t)
 
+	gitlabClient.On("UnprotectRepositoryBranches", pipelinePath, "pr_7_protected", mock.Anything).
+		Return(nil, nil).Once()
 	gitlabClient.On("ProtectRepositoryBranches", pipelinePath, mock.MatchedBy(func(opts *gitlab.ProtectRepositoryBranchesOptions) bool {
 		return opts.AllowForcePush != nil && *opts.AllowForcePush == true
 	})).Return(&gitlab.ProtectedBranch{}, nil).Once()

--- a/tests/tests/golden-files/test_issue_comment_integration.yml
+++ b/tests/tests/golden-files/test_issue_comment_integration.yml
@@ -1,6 +1,7 @@
 input: issue_comment_integration.json
 output:
 - 'github.IsOrganizationMember: org=mendersoftware,user=lluiscampos'
+- 'gitlab.UnprotectedBranch: path=Northern.tech/Mender/integration,branch=pr_2725_protected'
 - 'gitlab.ProtectedBranch: path=Northern.tech/Mender/integration,options={"name":"pr_2725_protected","allow_force_push":true}'
 - 'git.Run: /usr/bin/git init .'
 - 'git.Run: /usr/bin/git remote add github git@github.com:/mendersoftware/integration.git'


### PR DESCRIPTION
bring back unprotectBranch before re-protecting with allow-force-push so branches previously protected without allow-force-push are handled correctly also adding a retry loop on the push step to tolerate GitLab propagation delay after updating branch protection rules